### PR TITLE
Symlink exports for local development

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -10,7 +10,7 @@ mkdir -p "$dist_dir"
 
 # loop through all exports and create symlinks from src to dist
 while read -r export_path; do
-  src_path="${export_path/\.\/dist/src}"
+  src_path="$(pwd -P)/${export_path/\.\/dist/src}"
   src_path="${src_path%.js}.ts"
 
   dist_path="${export_path/\.\//}"

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Setting up symlinked exports, for local development..."
+package_file="./package.json"
+
+# Clear dist directory
+dist_dir="./dist"
+rm -rf "$dist_dir"
+mkdir -p "$dist_dir"
+
+# loop through all exports and create symlinks from src to dist
+while read -r export_path; do
+  src_path="${export_path/\.\/dist/src}"
+  src_path="${src_path%.js}.ts"
+
+  dist_path="${export_path/\.\//}"
+  dist_path_type="${dist_path%.js}.d.ts"
+  dist_dir=$(dirname "$dist_path")
+
+  mkdir -p "$dist_dir"
+  ln -sf "$src_path" "$dist_path"
+  ln -sf "$src_path" "$dist_path_type"
+
+  echo " $src_path"
+  echo "  ↪ $dist_path_type"
+  echo "  ↪ $dist_path"
+done < <(jq -r '.exports[] | objects | .default' "$package_file")
+
+echo "Done, all symlinks are set up! 🎉"


### PR DESCRIPTION
Simplifies local development by symlinking exports to the dist directory. 
This allows you to shift the compilation to the integrator during development, enabling fast refresh to work.

Caveats:
Only compatible with the [pnpm file protocol](https://pnpm.io/cli/link#whats-the-difference-between-pnpm-link-and-using-the-file-protocol)
The integrator must integrate [vanilla extract](https://vanilla-extract.style/documentation/integrations/next/)