### PR TITLE
CODEOWNERS, suppress notifications, file location

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @0xsequence-bot @0xsequence/marketplace

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @0xsequence/marketplace


### PR DESCRIPTION
Moved file to `.github` folder and added `@0xsequence-bot` as first code owner to suppress notifications. Same pattern as in `devops` repo.
https://github.com/0xsequence/devops/blob/master/.github/CODEOWNERS#L5