### PR TITLE
Configure Target Marketplace For Listings and Offers

### DIFF
--- a/packages/sdk/src/react/_internal/transaction-machine/execute-transaction.ts
+++ b/packages/sdk/src/react/_internal/transaction-machine/execute-transaction.ts
@@ -80,6 +80,7 @@ export interface TransactionConfig {
 	sdkConfig: SdkConfig;
 	marketplaceConfig: MarketplaceConfig;
 	isWaaS: boolean;
+	orderbookKind?: OrderbookKind;
 }
 
 interface StateConfig {
@@ -276,25 +277,33 @@ export class TransactionMachine {
 						.then((resp) => resp.steps);
 
 				case TransactionType.LISTING:
+					if (!this.config.config.orderbookKind) {
+						this.config.config.orderbookKind = OrderbookKind.sequence_marketplace_v2;
+					}
+
 					return await this.marketplaceClient
 						.generateListingTransaction({
 							collectionAddress,
 							owner: address,
 							walletType: this.config.config.walletKind,
 							contractType: props.contractType,
-							orderbook: OrderbookKind.sequence_marketplace_v2,
+							orderbook: this.config.config.orderbookKind,
 							listing: props.listing,
 						})
 						.then((resp) => resp.steps);
 
 				case TransactionType.OFFER:
+					if (!this.config.config.orderbookKind) {
+						this.config.config.orderbookKind = OrderbookKind.sequence_marketplace_v2;
+					}
+					
 					return await this.marketplaceClient
 						.generateOfferTransaction({
 							collectionAddress,
 							maker: address,
 							walletType: this.config.config.walletKind,
 							contractType: props.contractType,
-							orderbook: OrderbookKind.sequence_marketplace_v2,
+							orderbook: this.config.config.orderbookKind,
 							offer: props.offer,
 						})
 						.then((resp) => resp.steps);

--- a/packages/sdk/src/react/hooks/useBuyCollectable.tsx
+++ b/packages/sdk/src/react/hooks/useBuyCollectable.tsx
@@ -11,7 +11,7 @@ import {
 
 type UseBuyOrderError = TransactionErrorTypes;
 
-interface UseBuyOrderArgs extends Omit<UseTransactionMachineConfig, 'type'> {
+interface UseBuyOrderArgs extends Omit<UseTransactionMachineConfig, 'type' | 'orderbookKind'> {
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: UseBuyOrderError) => void;
 	onTransactionSent?: (hash: string) => void;

--- a/packages/sdk/src/react/hooks/useCancelOrder.tsx
+++ b/packages/sdk/src/react/hooks/useCancelOrder.tsx
@@ -7,7 +7,7 @@ import {
 	useTransactionMachine,
 } from '../_internal/transaction-machine/useTransactionMachine';
 
-interface UseCancelOrderArgs extends Omit<UseTransactionMachineConfig, 'type'> {
+interface UseCancelOrderArgs extends Omit<UseTransactionMachineConfig, 'type' | 'orderbookKind'> {
 	onSuccess?: (hash: string) => void;
 	onError?: (error: Error) => void;
 	onTransactionSent?: (hash: string) => void;

--- a/packages/sdk/src/react/hooks/useSell.tsx
+++ b/packages/sdk/src/react/hooks/useSell.tsx
@@ -10,7 +10,7 @@ import {
 	useTransactionMachine,
 } from '../_internal/transaction-machine/useTransactionMachine';
 
-interface UseSellArgs extends Omit<UseTransactionMachineConfig, 'type'> {
+interface UseSellArgs extends Omit<UseTransactionMachineConfig, 'type' | 'orderbookKind'> {
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: Error) => void;
 	onTransactionSent?: (hash: Hash) => void;

--- a/packages/sdk/src/react/ui/components/_internals/action-button/ActionButton.tsx
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/ActionButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '@0xsequence/design-system';
 import { observer } from '@legendapp/state/react';
 import type { Hex } from 'viem';
 import { InvalidStepError } from '../../../../../utils/_internal/error/transaction';
-import type { Order } from '../../../../_internal';
+import type { Order, OrderbookKind } from '../../../../_internal';
 import { useBuyModal } from '../../../modals/BuyModal';
 import { useCreateListingModal } from '../../../modals/CreateListingModal';
 import { useMakeOfferModal } from '../../../modals/MakeOfferModal';
@@ -23,6 +23,7 @@ type ActionButtonProps = {
 	chainId: string;
 	collectionAddress: Hex;
 	tokenId: string;
+	orderbookKind: OrderbookKind;
 	isTransfer?: boolean;
 	action: CollectibleCardAction;
 	isOwned: boolean;
@@ -35,6 +36,7 @@ export const ActionButton = observer(
 		collectionAddress,
 		chainId,
 		tokenId,
+		orderbookKind,
 		action,
 		highestOffer,
 		lowestListing,
@@ -92,6 +94,7 @@ export const ActionButton = observer(
 							collectionAddress: collectionAddress as Hex,
 							chainId: chainId,
 							collectibleId: tokenId,
+							orderbookKind
 						})
 					}
 				/>
@@ -107,6 +110,7 @@ export const ActionButton = observer(
 							collectionAddress: collectionAddress as Hex,
 							chainId: chainId,
 							collectibleId: tokenId,
+							orderbookKind
 						})
 					}
 				/>

--- a/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
@@ -8,6 +8,7 @@ import type {
 	CollectibleOrder,
 	ContractType,
 	Order,
+	OrderbookKind,
 } from '../../../_internal';
 import { useCurrencies, useHighestOffer } from '../../../hooks';
 import SvgDiamondEyeIcon from '../../icons/DiamondEye';
@@ -57,6 +58,7 @@ type CollectibleCardProps = {
 	collectibleId: string;
 	chainId: ChainId;
 	collectionAddress: Hex;
+	orderbookKind: OrderbookKind;
 	collectionType?: ContractType;
 	lowestListing: CollectibleOrder | undefined;
 	onCollectibleClick?: (tokenId: string) => void;
@@ -69,6 +71,7 @@ export function CollectibleCard({
 	collectibleId,
 	chainId,
 	collectionAddress,
+	orderbookKind,
 	collectionType,
 	lowestListing,
 	onCollectibleClick,
@@ -177,6 +180,7 @@ export function CollectibleCard({
 								chainId={String(chainId)}
 								collectionAddress={collectionAddress}
 								tokenId={collectibleId}
+								orderbookKind={orderbookKind}
 								action={action}
 								highestOffer={highestOffer?.order}
 								lowestListing={lowestListing?.order}

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/_store.ts
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/_store.ts
@@ -1,7 +1,7 @@
 import { observable } from '@legendapp/state';
 import { addDays } from 'date-fns/addDays';
 import type { Hash, Hex } from 'viem';
-import type { Currency } from '../../../../types';
+import { OrderbookKind, type Currency } from '../../../../types';
 import type { ModalCallbacks } from '../_internal/types';
 
 const initialState = {
@@ -9,6 +9,7 @@ const initialState = {
 	collectionAddress: '' as Hex,
 	chainId: '',
 	collectibleId: '',
+	orderbookKind: OrderbookKind.sequence_marketplace_v2,
 	collectionName: '',
 	collectionType: undefined,
 	listingPrice: {
@@ -27,6 +28,7 @@ const initialState = {
 		collectionAddress: Hex;
 		chainId: string;
 		collectibleId: string;
+		orderbookKind: OrderbookKind;
 		callbacks?: ModalCallbacks;
 		defaultCallbacks?: ModalCallbacks;
 		onSuccess?: (hash?: Hash) => void;
@@ -35,6 +37,7 @@ const initialState = {
 		createListingModal$.collectionAddress.set(args.collectionAddress);
 		createListingModal$.chainId.set(args.chainId);
 		createListingModal$.collectibleId.set(args.collectibleId);
+		createListingModal$.orderbookKind.set(args.orderbookKind);
 		createListingModal$.callbacks.set(args.callbacks || args.defaultCallbacks);
 		createListingModal$.onSuccess.set(args.onSuccess);
 		createListingModal$.onError.set(args.onError);

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
@@ -4,7 +4,7 @@ import type { QueryKey } from '@tanstack/react-query';
 import type { Hash, Hex } from 'viem';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
-import { type ContractType, collectableKeys } from '../../../_internal';
+import { type ContractType, OrderbookKind, collectableKeys } from '../../../_internal';
 import {
 	useBalanceOfCollectible,
 	useCollectible,
@@ -32,6 +32,7 @@ export type ShowCreateListingModalArgs = {
 	collectionAddress: Hex;
 	chainId: string;
 	collectibleId: string;
+	orderbookKind: OrderbookKind;
 	onSuccess?: (hash?: Hash) => void;
 	onError?: (error: Error) => void;
 };
@@ -64,7 +65,7 @@ export const Modal = observer(
 		showTransactionStatusModal: TransactionStatusModalReturn['show'];
 	}) => {
 		const state = createListingModal$.get();
-		const { collectionAddress, chainId, listingPrice, collectibleId } = state;
+		const { collectionAddress, chainId, listingPrice, collectibleId, orderbookKind } = state;
 		const {
 			data: collectible,
 			isLoading: collectableIsLoading,
@@ -93,6 +94,7 @@ export const Modal = observer(
 		});
 
 		const { getListingSteps, isLoading: machineLoading } = useCreateListing({
+			orderbookKind,
 			chainId,
 			collectionAddress,
 			onTransactionSent: (hash) => {

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/_store.ts
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/_store.ts
@@ -1,10 +1,11 @@
 import { observable } from '@legendapp/state';
 import { addDays } from 'date-fns/addDays';
 import type { Hex } from 'viem';
-import type { Currency, Price } from '../../../../types';
+import { Currency, OrderbookKind, Price } from '../../../../types';
 import type { BaseModalState, ModalCallbacks } from '../_internal/types';
 
 type MakeOfferModalState = BaseModalState & {
+	orderbookKind: OrderbookKind;
 	collectibleId: string;
 	offerPrice: Price;
 	quantity: string;
@@ -17,6 +18,7 @@ const initialState: MakeOfferModalState & {
 		collectionAddress: Hex;
 		chainId: string;
 		collectibleId: string;
+		orderbookKind: OrderbookKind;
 		callbacks?: ModalCallbacks;
 	}) => void;
 	close: () => void;
@@ -25,6 +27,7 @@ const initialState: MakeOfferModalState & {
 	collectionAddress: '' as Hex,
 	chainId: '',
 	collectibleId: '',
+	orderbookKind: OrderbookKind.sequence_marketplace_v2,
 	callbacks: undefined,
 	offerPrice: {
 		amountRaw: '1',
@@ -38,6 +41,7 @@ const initialState: MakeOfferModalState & {
 		makeOfferModal$.collectionAddress.set(args.collectionAddress);
 		makeOfferModal$.chainId.set(args.chainId);
 		makeOfferModal$.collectibleId.set(args.collectibleId);
+		makeOfferModal$.orderbookKind.set(args.orderbookKind);
 		makeOfferModal$.callbacks.set(args.callbacks);
 		makeOfferModal$.isOpen.set(true);
 	},

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -2,7 +2,7 @@ import { Show, observer } from '@legendapp/state/react';
 import type { QueryKey } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { parseUnits, type Hex } from 'viem';
-import { ContractType, collectableKeys } from '../../../_internal';
+import { ContractType, OrderbookKind, collectableKeys } from '../../../_internal';
 import { useCollectible, useCollection, useCurrencies } from '../../../hooks';
 import { useMakeOffer } from '../../../hooks/useMakeOffer';
 import { ActionModal } from '../_internal/components/actionModal/ActionModal';
@@ -22,6 +22,7 @@ export type ShowMakeOfferModalArgs = {
 	collectionAddress: Hex;
 	chainId: string;
 	collectibleId: string;
+	orderbookKind: OrderbookKind;
 };
 
 export const useMakeOfferModal = (defaultCallbacks?: ModalCallbacks) => ({
@@ -50,7 +51,7 @@ const ModalContent = observer(
 		showTransactionStatusModal: TransactionStatusModalReturn['show'];
 	}) => {
 		const state = makeOfferModal$.get();
-		const { collectionAddress, chainId, offerPrice, collectibleId } = state;
+		const { collectionAddress, chainId, offerPrice, collectibleId, orderbookKind } = state;
 		const [insufficientBalance, setInsufficientBalance] = useState(false);
 
 		const {
@@ -80,6 +81,7 @@ const ModalContent = observer(
 		const { getMakeOfferSteps } = useMakeOffer({
 			chainId,
 			collectionAddress,
+			orderbookKind,
 			onTransactionSent: (hash) => {
 				if (!hash) return;
 				showTransactionStatusModal({

--- a/playgrounds/react-vite/package.json
+++ b/playgrounds/react-vite/package.json
@@ -35,6 +35,7 @@
 		"wagmi": "catalog:"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
 		"@vanilla-extract/esbuild-plugin": "catalog:",

--- a/playgrounds/react-vite/src/lib/MarketplaceContext.tsx
+++ b/playgrounds/react-vite/src/lib/MarketplaceContext.tsx
@@ -1,5 +1,11 @@
-import type { SdkConfig } from '@0xsequence/marketplace-sdk';
-import { type ReactNode, createContext, useContext, useState, useEffect } from 'react';
+import { OrderbookKind, SdkConfig } from '@0xsequence/marketplace-sdk';
+import {
+	type ReactNode,
+	createContext,
+	useContext,
+	useState,
+	useEffect,
+} from 'react';
 import type { Hex } from 'viem';
 
 export type Tab = 'collections' | 'collectibles' | 'collectible';
@@ -23,6 +29,8 @@ interface MarketplaceContextType {
 	sdkConfig: SdkConfig;
 	isEmbeddedWalletEnabled: boolean;
 	setIsEmbeddedWalletEnabled: (enabled: boolean) => void;
+	orderbookKind: OrderbookKind;
+	setOrderbookKind: (kind: OrderbookKind) => void;
 }
 
 const MarketplaceContext = createContext<MarketplaceContextType | undefined>(
@@ -64,6 +72,7 @@ interface StoredSettings {
 	collectibleId: string;
 	projectId: string;
 	isEmbeddedWalletEnabled: boolean;
+	orderbookKind: OrderbookKind;
 }
 
 function loadStoredSettings(): Partial<StoredSettings> {
@@ -101,10 +110,8 @@ export function MarketplaceProvider({ children }: { children: ReactNode }) {
 	const [projectId, setProjectId] = useState(stored.projectId ?? '34598');
 	const projectAccessKey = 'AQAAAAAAADVH8R2AGuQhwQ1y8NaEf1T7PJM';
 
-	const [chainId, pendingChainId, setChainId, isChainIdValid] = useValidatedState<string>(
-		stored.chainId ?? '80002',
-		isNotUndefined,
-	);
+	const [chainId, pendingChainId, setChainId, isChainIdValid] =
+		useValidatedState<string>(stored.chainId ?? '80002', isNotUndefined);
 
 	const [
 		collectibleId,
@@ -116,7 +123,11 @@ export function MarketplaceProvider({ children }: { children: ReactNode }) {
 	const [activeTab, setActiveTab] = useState<Tab>('collections');
 
 	const [isEmbeddedWalletEnabled, setIsEmbeddedWalletEnabled] = useState(
-		stored.isEmbeddedWalletEnabled ?? false
+		stored.isEmbeddedWalletEnabled ?? false,
+	);
+
+	const [orderbookKind, setOrderbookKind] = useState<OrderbookKind>(
+		OrderbookKind.sequence_marketplace_v2,
 	);
 
 	// Save settings whenever they change
@@ -127,8 +138,16 @@ export function MarketplaceProvider({ children }: { children: ReactNode }) {
 			collectibleId,
 			projectId,
 			isEmbeddedWalletEnabled,
+			orderbookKind,
 		});
-	}, [collectionAddress, chainId, collectibleId, projectId, isEmbeddedWalletEnabled]);
+	}, [
+		collectionAddress,
+		chainId,
+		collectibleId,
+		projectId,
+		isEmbeddedWalletEnabled,
+		orderbookKind,
+	]);
 
 	const waasConfigKey =
 		'eyJwcm9qZWN0SWQiOjEzNjM5LCJycGNTZXJ2ZXIiOiJodHRwczovL3dhYXMuc2VxdWVuY2UuYXBwIn0';
@@ -161,6 +180,8 @@ export function MarketplaceProvider({ children }: { children: ReactNode }) {
 				setProjectId,
 				isEmbeddedWalletEnabled,
 				setIsEmbeddedWalletEnabled,
+				orderbookKind,
+				setOrderbookKind,
 				sdkConfig: {
 					projectId,
 					projectAccessKey,

--- a/playgrounds/react-vite/src/lib/Settings.tsx
+++ b/playgrounds/react-vite/src/lib/Settings.tsx
@@ -5,12 +5,27 @@ import {
 	Collapsible,
 	Divider,
 	Switch,
+	Select,
 } from '@0xsequence/design-system';
 import type { Hex } from 'viem';
 import { useMarketplace } from './MarketplaceContext';
 import { useAccount, useDisconnect } from 'wagmi';
 import { useOpenConnectModal } from '@0xsequence/kit';
 import { useState } from 'react';
+import { OrderbookKind } from '../../../../packages/sdk/src';
+
+/*
+export enum OrderbookKind {
+  unknown = 'unknown',
+  sequence_marketplace_v1 = 'sequence_marketplace_v1',
+  sequence_marketplace_v2 = 'sequence_marketplace_v2',
+  blur = 'blur',
+  opensea = 'opensea',
+  looks_rare = 'looks_rare',
+  reservoir = 'reservoir',
+  x2y2 = 'x2y2'
+}
+*/
 
 export function Settings() {
 	const { setOpenConnectModal } = useOpenConnectModal();
@@ -38,14 +53,20 @@ export function Settings() {
 		sdkConfig: { projectId },
 		isEmbeddedWalletEnabled,
 		setIsEmbeddedWalletEnabled,
+		setOrderbookKind,
 	} = useMarketplace();
 
 	const [pendingProjectId, setPendingProjectId] = useState(projectId);
 
 	const handleReset = () => {
-			localStorage.removeItem('marketplace_settings');
-			window.location.reload();
+		localStorage.removeItem('marketplace_settings');
+		window.location.reload();
 	};
+
+	const orderbookOptions = Object.keys(OrderbookKind).map((key) => ({
+		label: key,
+		value: key,
+	}));
 
 	return (
 		<Collapsible defaultOpen={true} label="Settings">
@@ -119,10 +140,19 @@ export function Settings() {
 						</Box>
 					}
 				/>
+				<Select
+					label="Orderbook"
+					labelLocation="top"
+					name="orderbook"
+					defaultValue={OrderbookKind.sequence_marketplace_v2}
+					options={orderbookOptions}
+					onValueChange={(value) => setOrderbookKind(value as OrderbookKind)}
+				/>
+
 				<Box paddingTop="3">
 					<Button
 						label="Reset Settings"
-						variant="secondary"
+						variant="raised"
 						shape="square"
 						onClick={handleReset}
 					/>

--- a/playgrounds/react-vite/src/lib/util/toTitleCaseFromSnakeCase.ts
+++ b/playgrounds/react-vite/src/lib/util/toTitleCaseFromSnakeCase.ts
@@ -1,0 +1,6 @@
+export default function toTitleCaseFromSnakeCase(str: string): string {
+	return str
+		.split('_')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+		.join(' ');
+}

--- a/playgrounds/react-vite/src/tabs/Collectables.tsx
+++ b/playgrounds/react-vite/src/tabs/Collectables.tsx
@@ -11,7 +11,7 @@ import { useAccount } from 'wagmi';
 import { useMarketplace } from '../lib/MarketplaceContext';
 
 export function Collectibles() {
-	const { collectionAddress, chainId, setCollectibleId, setActiveTab } =
+	const { collectionAddress, chainId, setCollectibleId, setActiveTab, orderbookKind } =
 		useMarketplace();
 	const { address: accountAddress } = useAccount();
 	const {
@@ -56,6 +56,7 @@ export function Collectibles() {
 							collectibleId={collectibleLowestListing.metadata.tokenId}
 							chainId={chainId}
 							collectionAddress={collectionAddress}
+							orderbookKind={orderbookKind}
 							collectionType={collection?.type as ContractType}
 							lowestListing={collectibleLowestListing}
 							onCollectibleClick={(tokenId) => {

--- a/playgrounds/react-vite/src/tabs/Debug.tsx
+++ b/playgrounds/react-vite/src/tabs/Debug.tsx
@@ -162,9 +162,9 @@ export function Debug() {
 					label="Open Chain Selector"
 					onClick={() => setIsChainModalOpen(true)}
 				/>
-				<ChainSwitchModal 
-					isOpen={isChainModalOpen} 
-					onClose={() => setIsChainModalOpen(false)} 
+				<ChainSwitchModal
+					isOpen={isChainModalOpen}
+					onClose={() => setIsChainModalOpen(false)}
 				/>
 			</Card>
 		</Box>
@@ -304,10 +304,7 @@ function ChainSwitchModal({ isOpen, onClose }: ChainSwitchModalProps) {
 	if (!isOpen) return null;
 
 	return (
-		<Modal
-			onClose={onClose}
-			size="sm"
-		>
+		<Modal onClose={onClose} size="sm">
 			<Box flexDirection="column" gap="2" padding="10">
 				{chains.map((chainInfo) => (
 					<Button

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
         specifier: 'catalog:'
         version: 2.13.4(@tanstack/query-core@5.62.3)(@tanstack/react-query@5.62.3(react@18.3.1))(@types/react@18.3.14)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.21.54(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
     devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 1.9.4
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.14


### PR DESCRIPTION
* Pass `TransactionMachine` an `orderbookKind` param to manage making orders for listing and offer for a specific marketplace but `sequence_marketplace_v2`. Set default to `sequence_marketplace_v2`
* Improve styling of playground and add a new cell to tables of offers and listings, `Orderbook`
