### PR TITLE
Fix .onerror not found and token approval flow

### DIFF
--- a/packages/sdk/src/react/_internal/transaction-machine/useTransactionMachine.ts
+++ b/packages/sdk/src/react/_internal/transaction-machine/useTransactionMachine.ts
@@ -21,20 +21,31 @@ export type UseTransactionMachineConfig = Omit<
 	'sdkConfig' | 'marketplaceConfig' | 'walletKind' | 'chains' | 'isWaaS'
 >;
 
-export const useTransactionMachine = (
-	config: UseTransactionMachineConfig,
-	onSuccess?: (hash: Hash) => void,
-	onError?: (error: TransactionError) => void,
+export const useTransactionMachine = ({
+	config,
+	enabled,
+	onSuccess,
+	onError,
+	onTransactionSent,
+	onApprovalSuccess,
+	onSwitchChainRefused,
+}: {
+	config: UseTransactionMachineConfig;
+	enabled: boolean;
+	onSuccess?: (hash: Hash) => void;
+	onError?: (error: TransactionError) => void;
 	onTransactionSent?: (
 		hash?: Hash,
 		orderId?: string,
 		isApproval?: boolean,
-	) => void,
-	onApprovalSuccess?: (hash: Hash) => void,
-) => {
+	) => void;
+	onApprovalSuccess?: (hash: Hash) => void;
+	onSwitchChainRefused: () => void;
+}) => {
 	const { data: walletClient, isLoading: walletClientIsLoading } =
 		useWalletClient();
-	const { show: showSwitchChainModal } = useSwitchChainModal();
+	const { show: showSwitchChainModal, close: closeSwitchChainModal } =
+		useSwitchChainModal();
 	const sdkConfig = useConfig();
 	const {
 		data: marketplaceConfig,
@@ -44,12 +55,14 @@ export const useTransactionMachine = (
 	const { openSelectPaymentModal } = useSelectPaymentModal();
 	const { chains } = useSwitchChain();
 
-	const { connector, isConnected } = useAccount();
+	const { connector, isConnected, chainId: accountChainId } = useAccount();
 	const walletKind =
 		connector?.id === 'sequence' ? WalletKind.sequence : WalletKind.unknown;
 
 	// TODO: remove this once we have a better way to check if the wallet is a WAAS wallet
 	const isWaaS = connector?.id.endsWith('waas') || false;
+
+	if (!enabled) return { machine: null, error: null, isLoading: false };
 
 	if (!isConnected) {
 		// No wallet connected, TODO: add some sort of state for this
@@ -78,6 +91,22 @@ export const useTransactionMachine = (
 		const error = new NoMarketplaceConfigError();
 		onError?.(error);
 		return { machine: null, error };
+	}
+
+	if (accountChainId !== Number(config.chainId)) {
+		showSwitchChainModal({
+			chainIdToSwitchTo: Number(config.chainId),
+			onSuccess: () => {
+				closeSwitchChainModal();
+			},
+			onError: (err) => {
+				throw err;
+			},
+			onClose: () => {
+				onSwitchChainRefused();
+			},
+		});
+		return { machine: null, error: null, isLoading: false };
 	}
 
 	const machine = new TransactionMachine(

--- a/packages/sdk/src/react/_internal/transaction-machine/useTransactionMachine.ts
+++ b/packages/sdk/src/react/_internal/transaction-machine/useTransactionMachine.ts
@@ -25,7 +25,12 @@ export const useTransactionMachine = (
 	config: UseTransactionMachineConfig,
 	onSuccess?: (hash: Hash) => void,
 	onError?: (error: TransactionError) => void,
-	onTransactionSent?: (hash?: Hash, orderId?: string) => void,
+	onTransactionSent?: (
+		hash?: Hash,
+		orderId?: string,
+		isApproval?: boolean,
+	) => void,
+	onApprovalSuccess?: (hash: Hash) => void,
 ) => {
 	const { data: walletClient, isLoading: walletClientIsLoading } =
 		useWalletClient();
@@ -87,6 +92,7 @@ export const useTransactionMachine = (
 			},
 			onSuccess,
 			onTransactionSent,
+			onApprovalSuccess,
 		},
 		walletClient,
 		getPublicRpcClient(config.chainId),

--- a/packages/sdk/src/react/hooks/useBuyCollectable.tsx
+++ b/packages/sdk/src/react/hooks/useBuyCollectable.tsx
@@ -16,23 +16,30 @@ interface UseBuyOrderArgs
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: UseBuyOrderError) => void;
 	onTransactionSent?: (hash?: Hex) => void;
+	onSwitchChainRefused: () => void;
+	enabled: boolean;
 }
 
 export const useBuyCollectable = ({
 	onSuccess,
 	onError,
 	onTransactionSent,
+	onSwitchChainRefused,
+	enabled,
 	...config
 }: UseBuyOrderArgs) => {
-	const { machine, error, isLoading } = useTransactionMachine(
-		{
-			...config,
-			type: TransactionType.BUY,
-		},
+	const machineConfig = {
+		...config,
+		type: TransactionType.BUY,
+	};
+	const { machine, error, isLoading } = useTransactionMachine({
+		config: machineConfig,
+		enabled,
+		onSwitchChainRefused,
 		onSuccess,
 		onError,
 		onTransactionSent,
-	);
+	});
 
 	return {
 		buy: (props: BuyInput) => {

--- a/packages/sdk/src/react/hooks/useCancelOrder.tsx
+++ b/packages/sdk/src/react/hooks/useCancelOrder.tsx
@@ -13,23 +13,30 @@ interface UseCancelOrderArgs
 	onSuccess?: (hash: string) => void;
 	onError?: (error: Error) => void;
 	onTransactionSent?: (hash?: Hex) => void;
+	onSwitchChainRefused: () => void;
+	enabled: boolean;
 }
 
 export const useCancelOrder = ({
 	onSuccess,
 	onError,
 	onTransactionSent,
+	onSwitchChainRefused,
+	enabled,
 	...config
 }: UseCancelOrderArgs) => {
-	const { machine, isLoading } = useTransactionMachine(
-		{
-			...config,
-			type: TransactionType.CANCEL,
-		},
+	const machineConfig = {
+		...config,
+		type: TransactionType.CANCEL,
+	};
+	const { machine, isLoading } = useTransactionMachine({
+		config: machineConfig,
+		enabled,
+		onSwitchChainRefused,
 		onSuccess,
 		onError,
 		onTransactionSent,
-	);
+	});
 
 	return {
 		cancel: (props: CancelInput) => machine?.start(props),

--- a/packages/sdk/src/react/hooks/useCreateListing.tsx
+++ b/packages/sdk/src/react/hooks/useCreateListing.tsx
@@ -16,12 +16,14 @@ interface UseCreateListingArgs
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: TransactionError) => void;
 	onTransactionSent?: (hash?: Hash, orderId?: string) => void;
+	onApprovalSuccess?: (hash: Hash) => void;
 }
 
 export const useCreateListing = ({
 	onSuccess,
 	onError,
 	onTransactionSent,
+	onApprovalSuccess,
 	...config
 }: UseCreateListingArgs) => {
 	const [isLoading, setIsLoading] = useState(false);
@@ -35,6 +37,7 @@ export const useCreateListing = ({
 		onSuccess,
 		onError,
 		onTransactionSent,
+		onApprovalSuccess,
 	);
 
 	const loadSteps = useCallback(

--- a/packages/sdk/src/react/hooks/useCreateListing.tsx
+++ b/packages/sdk/src/react/hooks/useCreateListing.tsx
@@ -17,6 +17,8 @@ interface UseCreateListingArgs
 	onError?: (error: TransactionError) => void;
 	onTransactionSent?: (hash?: Hash, orderId?: string) => void;
 	onApprovalSuccess?: (hash: Hash) => void;
+	onSwitchChainRefused: () => void;
+	enabled: boolean;
 }
 
 export const useCreateListing = ({
@@ -24,21 +26,26 @@ export const useCreateListing = ({
 	onError,
 	onTransactionSent,
 	onApprovalSuccess,
+	onSwitchChainRefused,
+	enabled,
 	...config
 }: UseCreateListingArgs) => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [steps, setSteps] = useState<TransactionSteps | null>(null);
+	const machineConfig = {
+		...config,
+		type: TransactionType.LISTING,
+	};
 
-	const { machine, isLoading: isMachineLoading } = useTransactionMachine(
-		{
-			...config,
-			type: TransactionType.LISTING,
-		},
+	const { machine, isLoading: isMachineLoading } = useTransactionMachine({
+		config: machineConfig,
+		enabled,
 		onSuccess,
 		onError,
 		onTransactionSent,
 		onApprovalSuccess,
-	);
+		onSwitchChainRefused,
+	});
 
 	const loadSteps = useCallback(
 		async (props: ListingInput) => {

--- a/packages/sdk/src/react/hooks/useMakeOffer.tsx
+++ b/packages/sdk/src/react/hooks/useMakeOffer.tsx
@@ -16,6 +16,8 @@ interface UseMakeOfferArgs extends Omit<UseTransactionMachineConfig, 'type'> {
 	onError?: (error: TransactionError) => void;
 	onTransactionSent?: (hash?: Hash, orderId?: string) => void;
 	onApprovalSuccess?: (hash: Hash) => void;
+	onSwitchChainRefused: () => void;
+	enabled: boolean;
 }
 
 export const useMakeOffer = ({
@@ -23,21 +25,26 @@ export const useMakeOffer = ({
 	onError,
 	onTransactionSent,
 	onApprovalSuccess,
+	onSwitchChainRefused,
+	enabled,
 	...config
 }: UseMakeOfferArgs) => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [steps, setSteps] = useState<TransactionSteps | null>(null);
+	const machineConfig = {
+		...config,
+		type: TransactionType.OFFER,
+	};
 
-	const { machine, isLoading: isMachineLoading } = useTransactionMachine(
-		{
-			...config,
-			type: TransactionType.OFFER,
-		},
+	const { machine, isLoading: isMachineLoading } = useTransactionMachine({
+		config: machineConfig,
+		enabled,
 		onSuccess,
 		onError,
 		onTransactionSent,
 		onApprovalSuccess,
-	);
+		onSwitchChainRefused,
+	});
 
 	const loadSteps = useCallback(
 		async (props: OfferInput) => {

--- a/packages/sdk/src/react/hooks/useMakeOffer.tsx
+++ b/packages/sdk/src/react/hooks/useMakeOffer.tsx
@@ -15,12 +15,14 @@ interface UseMakeOfferArgs extends Omit<UseTransactionMachineConfig, 'type'> {
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: TransactionError) => void;
 	onTransactionSent?: (hash?: Hash, orderId?: string) => void;
+	onApprovalSuccess?: (hash: Hash) => void;
 }
 
 export const useMakeOffer = ({
 	onSuccess,
 	onError,
 	onTransactionSent,
+	onApprovalSuccess,
 	...config
 }: UseMakeOfferArgs) => {
 	const [isLoading, setIsLoading] = useState(false);
@@ -34,6 +36,7 @@ export const useMakeOffer = ({
 		onSuccess,
 		onError,
 		onTransactionSent,
+		onApprovalSuccess,
 	);
 
 	const loadSteps = useCallback(

--- a/packages/sdk/src/react/hooks/useSell.tsx
+++ b/packages/sdk/src/react/hooks/useSell.tsx
@@ -15,26 +15,33 @@ interface UseSellArgs
 	onSuccess?: (hash: Hash) => void;
 	onError?: (error: Error) => void;
 	onTransactionSent?: (hash?: Hash) => void;
+	onSwitchChainRefused: () => void;
+	enabled: boolean;
 }
 
 export const useSell = ({
 	onSuccess,
 	onError,
 	onTransactionSent,
+	onSwitchChainRefused,
+	enabled,
 	...config
 }: UseSellArgs) => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [steps, setSteps] = useState<TransactionSteps | null>(null);
+	const machineConfig = {
+		...config,
+		type: TransactionType.SELL,
+	};
 
-	const { machine, isLoading: isMachineLoading } = useTransactionMachine(
-		{
-			...config,
-			type: TransactionType.SELL,
-		},
+	const { machine, isLoading: isMachineLoading } = useTransactionMachine({
+		config: machineConfig,
+		enabled,
+		onSwitchChainRefused,
 		onSuccess,
 		onError,
 		onTransactionSent,
-	);
+	});
 
 	const loadSteps = useCallback(
 		async (props: SellInput) => {

--- a/packages/sdk/src/react/ui/modals/BuyModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/index.tsx
@@ -53,6 +53,10 @@ export const BuyModalContent = () => {
 	const { buy, isLoading } = useBuyCollectable({
 		chainId,
 		collectionAddress,
+		enabled: buyModal$.isOpen.get(),
+		onSwitchChainRefused: () => {
+			buyModal$.close();
+		},
 		onError: (error) => {
 			if (callbacks?.onError) {
 				callbacks.onError(error);

--- a/packages/sdk/src/react/ui/modals/BuyModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/index.tsx
@@ -43,6 +43,7 @@ export const BuyModalContent = () => {
 	) as Hex;
 	const collectibleId = useSelector(buyModal$.state.order.tokenId);
 	const modalId = useSelector(buyModal$.state.modalId);
+	const callbacks = useSelector(buyModal$.callbacks);
 
 	const { data: collection } = useCollection({
 		chainId,
@@ -52,9 +53,19 @@ export const BuyModalContent = () => {
 	const { buy, isLoading } = useBuyCollectable({
 		chainId,
 		collectionAddress,
-		onError: buyModal$.callbacks.get()?.onError,
+		onError: (error) => {
+			if (callbacks?.onError) {
+				callbacks.onError(error);
+			} else {
+				console.debug('onError callback not provided', error);
+			}
+		},
 		onSuccess: (hash) => {
-			buyModal$.callbacks.get()?.onSuccess?.(hash);
+			if (callbacks?.onSuccess) {
+				callbacks.onSuccess(hash);
+			} else {
+				console.debug('onSuccess callback not provided', hash);
+			}
 			buyModal$.close();
 		},
 	});

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/_store.ts
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/_store.ts
@@ -13,9 +13,12 @@ const initialState = {
 	collectionName: '',
 	collectionType: undefined,
 	listingPrice: {
-		amountRaw: '0',
+		// to see if approval is needed when modal opens
+		amountRaw: '1',
 		currency: {} as Currency,
 	},
+	// to track if the user has changed the price, so we know if it's 1 default or user input
+	listingPriceChanged: false,
 	quantity: '1',
 	invalidQuantity: false,
 	expiry: new Date(addDays(new Date(), 7).toJSON()),

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
@@ -113,6 +113,8 @@ export const Modal = observer(
 			orderbookKind,
 			chainId,
 			collectionAddress,
+			enabled: createListingModal$.isOpen.get(),
+			onSwitchChainRefused: () => createListingModal$.close(),
 			onApprovalSuccess: () => setApprovalExecutedSuccess(true),
 			onTransactionSent: (hash, orderId) => {
 				if (!hash && !orderId) return;

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
@@ -31,6 +31,7 @@ import { useTransactionStatusModal } from '../_internal/components/transactionSt
 import type { ModalCallbacks } from '../_internal/types';
 import { createListingModal$ } from './_store';
 import { TransactionType } from '../../../_internal/transaction-machine/execute-transaction';
+import { useEffect, useState } from 'react';
 
 export type ShowCreateListingModalArgs = {
 	collectionAddress: Hex;
@@ -73,8 +74,10 @@ export const Modal = observer(
 			collectionAddress,
 			chainId,
 			listingPrice,
+			listingPriceChanged,
 			collectibleId,
 			orderbookKind,
+			onError,
 		} = state;
 		const {
 			data: collectible,
@@ -93,6 +96,8 @@ export const Modal = observer(
 			chainId,
 			collectionAddress,
 		});
+		const [approvalExecutedSuccess, setApprovalExecutedSuccess] =
+			useState(false);
 
 		const { address } = useAccount();
 
@@ -107,6 +112,7 @@ export const Modal = observer(
 			orderbookKind,
 			chainId,
 			collectionAddress,
+			onApprovalSuccess: () => setApprovalExecutedSuccess(true),
 			onTransactionSent: (hash, orderId) => {
 				if (!hash && !orderId) return;
 
@@ -123,8 +129,8 @@ export const Modal = observer(
 				createListingModal$.close();
 			},
 			onError: (error) => {
-				if (typeof createListingModal$.callbacks?.onError === 'function') {
-					createListingModal$.onError(error);
+				if (onError) {
+					onError(error);
 				} else {
 					console.debug('onError callback not provided:', error);
 				}
@@ -138,7 +144,11 @@ export const Modal = observer(
 				await refreshSteps();
 				await execute();
 			} catch (error) {
-				createListingModal$.onError?.(error as Error);
+				if (onError) {
+					onError(error as Error);
+				} else {
+					console.debug('onError callback not provided:', error);
+				}
 			}
 		};
 
@@ -165,6 +175,8 @@ export const Modal = observer(
 		const dateToUnixTime = (date: Date) =>
 			Math.floor(date.getTime() / 1000).toString();
 
+		const currencyAddress = listingPrice.currency.contractAddress;
+
 		const { isLoading, steps, refreshSteps } = getListingSteps({
 			contractType: collection!.type as ContractType,
 			listing: {
@@ -178,25 +190,38 @@ export const Modal = observer(
 				pricePerToken: listingPrice.amountRaw,
 			},
 		});
+		const approvalNeeded = steps?.approval.isPending;
+
+		useEffect(() => {
+			if (!currencyAddress) return;
+
+			refreshSteps();
+		}, [currencyAddress]);
 
 		const ctas = [
 			{
 				label: 'Approve TOKEN',
 				onClick: () => handleStepExecution(() => steps?.approval.execute()),
-				hidden: !steps?.approval.isPending,
-				pending: steps?.approval.isExecuting,
+				hidden: !approvalNeeded || approvalExecutedSuccess,
+				pending: steps?.approval.isExecuting || isLoading,
 				variant: 'glass' as const,
-				disabled: createListingModal$.invalidQuantity.get(),
+				disabled:
+					createListingModal$.invalidQuantity.get() ||
+					isLoading ||
+					!listingPriceChanged ||
+					listingPrice.amountRaw === '0' ||
+					steps?.transaction.isExecuting,
 			},
 			{
 				label: 'List item for sale',
 				onClick: () => handleStepExecution(() => steps?.transaction.execute()),
 				pending: steps?.transaction.isExecuting || isLoading,
 				disabled:
-					steps?.approval.isPending ||
+					(!approvalExecutedSuccess && approvalNeeded) ||
 					listingPrice.amountRaw === '0' ||
 					isLoading ||
-					createListingModal$.invalidQuantity.get(),
+					createListingModal$.invalidQuantity.get() ||
+					!listingPriceChanged,
 			},
 		] satisfies ActionModalProps['ctas'];
 
@@ -219,8 +244,11 @@ export const Modal = observer(
 						chainId={chainId}
 						collectionAddress={collectionAddress}
 						$listingPrice={createListingModal$.listingPrice}
+						onPriceChange={() =>
+							createListingModal$.listingPriceChanged.set(true)
+						}
 					/>
-					{!!listingPrice && (
+					{!!listingPrice && listingPriceChanged && (
 						<FloorPriceText
 							tokenId={collectibleId}
 							chainId={chainId}
@@ -246,6 +274,7 @@ export const Modal = observer(
 					collectionAddress={collectionAddress}
 					chainId={chainId}
 					price={createListingModal$.listingPrice.get()}
+					priceChanged={listingPriceChanged}
 					currencyImageUrl={listingPrice.currency.imageUrl}
 				/>
 			</ActionModal>

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
@@ -249,8 +249,8 @@ export const Modal = observer(
 							createListingModal$.listingPriceChanged.set(true)
 						}
 					/>
-          
-					{listingPrice.amountRaw !== '0'&& listingPriceChanged && (
+
+					{listingPrice.amountRaw !== '0' && listingPriceChanged && (
 						<FloorPriceText
 							tokenId={collectibleId}
 							chainId={chainId}

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/index.tsx
@@ -88,6 +88,7 @@ export const Modal = observer(
 			collectionAddress,
 			collectibleId,
 		});
+
 		const {
 			data: collection,
 			isLoading: collectionIsLoading,
@@ -248,7 +249,8 @@ export const Modal = observer(
 							createListingModal$.listingPriceChanged.set(true)
 						}
 					/>
-					{!!listingPrice && listingPriceChanged && (
+          
+					{listingPrice.amountRaw !== '0'&& listingPriceChanged && (
 						<FloorPriceText
 							tokenId={collectibleId}
 							chainId={chainId}

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/_store.ts
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/_store.ts
@@ -8,6 +8,7 @@ type MakeOfferModalState = BaseModalState & {
 	orderbookKind: OrderbookKind;
 	collectibleId: string;
 	offerPrice: Price;
+	offerPriceChanged: boolean;
 	quantity: string;
 	expiry: Date;
 	invalidQuantity: boolean;
@@ -27,12 +28,14 @@ const initialState: MakeOfferModalState & {
 	collectionAddress: '' as Hex,
 	chainId: '',
 	collectibleId: '',
-	orderbookKind: OrderbookKind.sequence_marketplace_v2,
+	orderbookKind: OrderbookKind.reservoir,
 	callbacks: undefined,
 	offerPrice: {
 		amountRaw: '1',
 		currency: {} as Currency,
 	},
+	// to track if the user has changed the price, so we know if it's 1 default or user input
+	offerPriceChanged: false,
 	quantity: '1',
 	invalidQuantity: false,
 	expiry: new Date(addDays(new Date(), 7).toJSON()),

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -203,7 +203,8 @@ const ModalContent = observer(
 					isLoading ||
 					steps?.transaction.isExecuting ||
 					insufficientBalance ||
-					offerPrice.amountRaw === '0',
+					offerPrice.amountRaw === '0' ||
+					!offerPriceChanged,
 			},
 			{
 				label: 'Make offer',
@@ -237,6 +238,7 @@ const ModalContent = observer(
 					chainId={chainId}
 					collectionAddress={collectionAddress}
 					$listingPrice={makeOfferModal$.offerPrice}
+					priceChanged={makeOfferModal$.offerPriceChanged.get()}
 					onPriceChange={() => makeOfferModal$.offerPriceChanged.set(true)}
 					checkBalance={{
 						enabled: true,

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -199,7 +199,11 @@ const ModalContent = observer(
 				pending: steps?.approval.isExecuting || isLoading,
 				variant: 'glass' as const,
 				disabled:
-					invalidQuantity || isLoading || steps?.transaction.isExecuting,
+					invalidQuantity ||
+					isLoading ||
+					steps?.transaction.isExecuting ||
+					insufficientBalance ||
+					offerPrice.amountRaw === '0',
 			},
 			{
 				label: 'Make offer',

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -65,7 +65,8 @@ const ModalContent = observer(
 			callbacks,
 		} = state;
 		const [insufficientBalance, setInsufficientBalance] = useState(false);
-
+		const [approvalExecutedSuccess, setApprovalExecutedSuccess] =
+			useState(false);
 		const {
 			data: collectible,
 			isLoading: collectableIsLoading,
@@ -94,6 +95,7 @@ const ModalContent = observer(
 			chainId,
 			collectionAddress,
 			orderbookKind,
+			onApprovalSuccess: () => setApprovalExecutedSuccess(true),
 			onTransactionSent: (hash, orderId) => {
 				if (!hash && !orderId) return;
 
@@ -143,6 +145,7 @@ const ModalContent = observer(
 				pricePerToken: offerPrice.amountRaw,
 			},
 		});
+		const approvalNeeded = steps?.approval.isPending;
 
 		useEffect(() => {
 			if (!currencyAddress) return;
@@ -188,20 +191,20 @@ const ModalContent = observer(
 			{
 				label: 'Approve TOKEN',
 				onClick: () => handleStepExecution(() => steps?.approval.execute()),
-				hidden: !steps?.approval.isPending,
-				pending: steps?.approval.isExecuting,
+				hidden: !approvalNeeded || approvalExecutedSuccess,
+				pending: steps?.approval.isExecuting || isLoading,
 				variant: 'glass' as const,
 				disabled:
 					makeOfferModal$.invalidQuantity.get() ||
 					isLoading ||
-					insufficientBalance,
+					steps?.transaction.isExecuting,
 			},
 			{
 				label: 'Make offer',
 				onClick: () => handleStepExecution(() => steps?.transaction.execute()),
 				pending: steps?.transaction.isExecuting || isLoading,
 				disabled:
-					steps?.approval.isPending ||
+					(!approvalExecutedSuccess && approvalNeeded) ||
 					offerPrice.amountRaw === '0' ||
 					insufficientBalance ||
 					isLoading ||

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -97,6 +97,8 @@ const ModalContent = observer(
 			chainId,
 			collectionAddress,
 			orderbookKind,
+			enabled: makeOfferModal$.isOpen.get(),
+			onSwitchChainRefused: () => makeOfferModal$.close(),
 			onApprovalSuccess: () => setApprovalExecutedSuccess(true),
 			onTransactionSent: (hash, orderId) => {
 				if (!hash && !orderId) return;
@@ -197,9 +199,7 @@ const ModalContent = observer(
 				pending: steps?.approval.isExecuting || isLoading,
 				variant: 'glass' as const,
 				disabled:
-					invalidQuantity ||
-					isLoading ||
-					steps?.transaction.isExecuting
+					invalidQuantity || isLoading || steps?.transaction.isExecuting,
 			},
 			{
 				label: 'Make offer',

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/index.tsx
@@ -60,6 +60,8 @@ const ModalContent = observer(
 			collectionAddress,
 			chainId,
 			offerPrice,
+			offerPriceChanged,
+			invalidQuantity,
 			collectibleId,
 			orderbookKind,
 			callbacks,
@@ -195,9 +197,9 @@ const ModalContent = observer(
 				pending: steps?.approval.isExecuting || isLoading,
 				variant: 'glass' as const,
 				disabled:
-					makeOfferModal$.invalidQuantity.get() ||
+					invalidQuantity ||
 					isLoading ||
-					steps?.transaction.isExecuting,
+					steps?.transaction.isExecuting
 			},
 			{
 				label: 'Make offer',
@@ -208,7 +210,8 @@ const ModalContent = observer(
 					offerPrice.amountRaw === '0' ||
 					insufficientBalance ||
 					isLoading ||
-					makeOfferModal$.invalidQuantity.get(),
+					invalidQuantity ||
+					offerPrice.amountRaw === '0',
 			},
 		];
 
@@ -230,6 +233,7 @@ const ModalContent = observer(
 					chainId={chainId}
 					collectionAddress={collectionAddress}
 					$listingPrice={makeOfferModal$.offerPrice}
+					onPriceChange={() => makeOfferModal$.offerPriceChanged.set(true)}
 					checkBalance={{
 						enabled: true,
 						callback: (state) => setInsufficientBalance(state),
@@ -245,14 +249,16 @@ const ModalContent = observer(
 					/>
 				)}
 
-				{!!offerPrice && (
-					<FloorPriceText
-						tokenId={collectibleId}
-						chainId={chainId}
-						collectionAddress={collectionAddress}
-						price={offerPrice}
-					/>
-				)}
+				{offerPrice.amountRaw !== '0' &&
+					offerPriceChanged &&
+					!insufficientBalance && (
+						<FloorPriceText
+							tokenId={collectibleId}
+							chainId={chainId}
+							collectionAddress={collectionAddress}
+							price={offerPrice}
+						/>
+					)}
 
 				<ExpirationDateSelect $date={makeOfferModal$.expiry} />
 			</ActionModal>

--- a/packages/sdk/src/react/ui/modals/SellModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/index.tsx
@@ -63,6 +63,10 @@ const ModalContent = observer(
 		const { sell } = useSell({
 			collectionAddress,
 			chainId,
+			enabled: sellModal$.isOpen.get(),
+			onSwitchChainRefused: () => {
+				sellModal$.close();
+			},
 			onTransactionSent: (hash) => {
 				if (!hash) return;
 				showTransactionStatusModal({

--- a/packages/sdk/src/react/ui/modals/SellModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/index.tsx
@@ -53,7 +53,8 @@ const ModalContent = observer(
 	}: {
 		showTransactionStatusModal: TransactionStatusModalReturn['show'];
 	}) => {
-		const { tokenId, collectionAddress, chainId, order } = sellModal$.get();
+		const { tokenId, collectionAddress, chainId, order, callbacks } =
+			sellModal$.get();
 		const { data: collectible } = useCollection({
 			chainId,
 			collectionAddress,
@@ -85,15 +86,15 @@ const ModalContent = observer(
 				sellModal$.close();
 			},
 			onSuccess: (hash) => {
-				if (typeof sellModal$.callbacks?.onSuccess === 'function') {
-					sellModal$.callbacks.onSuccess(hash);
+				if (callbacks?.onSuccess) {
+					callbacks.onSuccess(hash);
 				} else {
 					console.debug('onSuccess callback not provided:', hash);
 				}
 			},
 			onError: (error) => {
-				if (typeof sellModal$.callbacks?.onError === 'function') {
-					sellModal$.callbacks.onError(error);
+				if (callbacks?.onError) {
+					callbacks.onError(error);
 				} else {
 					console.debug('onError callback not provided:', error);
 				}

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -24,7 +24,6 @@ type PriceInputProps = {
 const PriceInput = observer(function PriceInput({
 	chainId,
 	collectionAddress,
-	onPriceChange,
 	$listingPrice,
 	onPriceChange,
 	checkBalance,

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -14,6 +14,7 @@ type PriceInputProps = {
 	collectionAddress: Hex;
 	chainId: string;
 	$listingPrice: Observable<Price | undefined>;
+	onPriceChange?: () => void;
 	checkBalance?: {
 		enabled: boolean;
 		callback: (state: boolean) => void;
@@ -24,6 +25,7 @@ const PriceInput = observer(function PriceInput({
 	chainId,
 	collectionAddress,
 	$listingPrice,
+	onPriceChange,
 	checkBalance,
 }: PriceInputProps) {
 	const [balanceError, setBalanceError] = useState('');
@@ -61,6 +63,7 @@ const PriceInput = observer(function PriceInput({
 		const parsedAmount = parseUnits(value, Number(currencyDecimals));
 		$listingPrice.amountRaw.set(parsedAmount.toString());
 		checkBalance && checkInsufficientBalance(parsedAmount.toString());
+		onPriceChange && onPriceChange();
 	};
 
 	return (

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -1,7 +1,7 @@
-import { Box, NumericInput } from '@0xsequence/design-system';
+import { Box, NumericInput, Text } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { observer } from '@legendapp/state/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type Hex, parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import type { Price } from '../../../../../../types';
@@ -24,6 +24,7 @@ type PriceInputProps = {
 const PriceInput = observer(function PriceInput({
 	chainId,
 	collectionAddress,
+	onPriceChange,
 	$listingPrice,
 	onPriceChange,
 	checkBalance,
@@ -39,6 +40,11 @@ const PriceInput = observer(function PriceInput({
 	const currencyDecimals = $listingPrice.currency.decimals.get();
 
 	const [value, setValue] = useState('');
+
+	useEffect(() => {
+		const parsedAmount = parseUnits(value, Number(currencyDecimals));
+		$listingPrice.amountRaw.set(parsedAmount.toString());
+	}, [value, currencyDecimals]);
 
 	const checkInsufficientBalance = (priceAmountRaw: string) => {
 		const hasInsufficientBalance =
@@ -60,11 +66,15 @@ const PriceInput = observer(function PriceInput({
 
 	const changeListingPrice = (value: string) => {
 		setValue(value);
-		const parsedAmount = parseUnits(value, Number(currencyDecimals));
-		$listingPrice.amountRaw.set(parsedAmount.toString());
-		checkBalance && checkInsufficientBalance(parsedAmount.toString());
-		onPriceChange && onPriceChange();
+		onPriceChange?.();
 	};
+
+	useEffect(() => {
+		const priceAmountRaw = $listingPrice.amountRaw.get();
+		if (priceAmountRaw) {
+			checkInsufficientBalance(priceAmountRaw);
+		}
+	}, [$listingPrice.amountRaw.get(), $listingPrice.currency.get()]);
 
 	return (
 		<Box className={priceInputWrapper} position="relative">
@@ -94,10 +104,18 @@ const PriceInput = observer(function PriceInput({
 				onChange={(event) => changeListingPrice(event.target.value)}
 				width="full"
 			/>
+
 			{balanceError && (
-				<Box color="negative" fontSize="small">
+				<Text
+					color="negative"
+					fontSize="xsmall"
+					fontFamily="body"
+					fontWeight="semibold"
+					position="absolute"
+					style={{ bottom: '-13px' }}
+				>
 					{balanceError}
-				</Box>
+				</Text>
 			)}
 		</Box>
 	);

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -14,6 +14,7 @@ type PriceInputProps = {
 	collectionAddress: Hex;
 	chainId: string;
 	$listingPrice: Observable<Price | undefined>;
+	priceChanged?: boolean;
 	onPriceChange?: () => void;
 	checkBalance?: {
 		enabled: boolean;
@@ -25,6 +26,7 @@ const PriceInput = observer(function PriceInput({
 	chainId,
 	collectionAddress,
 	$listingPrice,
+	priceChanged,
 	onPriceChange,
 	checkBalance,
 }: PriceInputProps) {
@@ -41,6 +43,8 @@ const PriceInput = observer(function PriceInput({
 	const [value, setValue] = useState('');
 
 	useEffect(() => {
+		if (!priceChanged) return;
+
 		const parsedAmount = parseUnits(value, Number(currencyDecimals));
 		$listingPrice.amountRaw.set(parsedAmount.toString());
 	}, [value, currencyDecimals]);
@@ -70,7 +74,7 @@ const PriceInput = observer(function PriceInput({
 
 	useEffect(() => {
 		const priceAmountRaw = $listingPrice.amountRaw.get();
-		if (priceAmountRaw) {
+		if (priceAmountRaw && priceAmountRaw !== '0') {
 			checkInsufficientBalance(priceAmountRaw);
 		}
 	}, [$listingPrice.amountRaw.get(), $listingPrice.currency.get()]);

--- a/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
@@ -30,7 +30,7 @@ export type ShowSwitchChainModalArgs = {
 export const useSwitchChainModal = () => {
 	return {
 		show: (args: ShowSwitchChainModalArgs) => switchChainModal$.open(args),
-		close: () => switchChainModal$.close(),
+		close: () => switchChainModal$.delete(),
 		isSwitching$: switchChainModal$.state.isSwitching,
 	};
 };
@@ -49,7 +49,7 @@ const SwitchChainModal = observer(() => {
 
 			switchChainModal$.state.onSuccess?.();
 
-			switchChainModal$.close();
+			switchChainModal$.delete();
 		} catch (error) {
 			switchChainModal$.state.onError?.(error as SwitchChainErrorType);
 		} finally {

--- a/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
@@ -45,18 +45,18 @@ export default function TransactionDetails({
 	let formattedAmount =
 		price && formatUnits(BigInt(price.amountRaw), price.currency.decimals);
 
-	if (royaltyPercentage !== undefined && formattedAmount) {
+	if (royaltyPercentage !== undefined && formattedAmount && price) {
 		formattedAmount = (
 			Number.parseFloat(formattedAmount) -
 			(Number.parseFloat(formattedAmount) * Number(royaltyPercentage)) / 100
-		).toString();
+		).toFixed(price.currency.decimals);
 	}
 
-	if (marketplaceFeePercentage !== undefined && formattedAmount) {
+	if (marketplaceFeePercentage !== undefined && formattedAmount && price) {
 		formattedAmount = (
 			Number.parseFloat(formattedAmount) -
 			(Number.parseFloat(formattedAmount) * marketplaceFeePercentage) / 100
-		).toString();
+		).toFixed(price.currency.decimals);
 	}
 
 	return (

--- a/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
@@ -11,6 +11,7 @@ type TransactionDetailsProps = {
 	collectionAddress: Hex;
 	chainId: string;
 	price?: Price;
+	priceChanged?: boolean;
 	currencyImageUrl?: string;
 };
 
@@ -22,6 +23,7 @@ export default function TransactionDetails({
 	collectionAddress,
 	chainId,
 	price,
+	priceChanged,
 	currencyImageUrl,
 }: TransactionDetailsProps) {
 	const { data, isLoading: marketplaceConfigLoading } = useMarketplaceConfig();
@@ -75,7 +77,7 @@ export default function TransactionDetails({
 					<Skeleton width="16" height={'4'} />
 				) : (
 					<Text fontSize={'small'} color={'text100'} fontFamily="body">
-						{formattedAmount} {price.currency.symbol}
+						{priceChanged ? formattedAmount : '0'} {price.currency.symbol}
 					</Text>
 				)}
 			</Box>

--- a/packages/sdk/src/utils/price.ts
+++ b/packages/sdk/src/utils/price.ts
@@ -11,11 +11,10 @@ export const calculatePriceDifferencePercentage = ({
 	basePriceRaw,
 	decimals,
 }: CalculatePriceDifferencePercentageArgs) => {
-	const difference = Number(
-		formatUnits(inputPriceRaw - basePriceRaw, decimals),
-	);
+	const inputPrice = Number(formatUnits(inputPriceRaw, decimals));
 	const basePrice = Number(formatUnits(basePriceRaw, decimals));
+	const difference = inputPrice - basePrice;
 	const percentageDifference = (difference / basePrice) * 100;
 
-	return Math.abs(percentageDifference).toFixed(2);
+	return percentageDifference.toFixed(2);
 };

--- a/playgrounds/react-vite/src/tabs/Collectable.tsx
+++ b/playgrounds/react-vite/src/tabs/Collectable.tsx
@@ -241,6 +241,10 @@ function ListingsTable() {
 	const { cancel } = useCancelOrder({
 		collectionAddress,
 		chainId,
+		enabled: cancelTransactionExecuting,
+		onSwitchChainRefused: () => {
+			setCancelTransactionExecuting(false);
+		},
 		onSuccess: (hash) => {
 			toast({
 				title: 'Success',
@@ -367,6 +371,10 @@ function OffersTable() {
 	const { cancel } = useCancelOrder({
 		collectionAddress,
 		chainId,
+		enabled: cancelTransactionExecuting,
+		onSwitchChainRefused: () => {
+			setCancelTransactionExecuting(false);
+		}
 	});
 	const owned = balance?.balance || 0;
 	const toast = useToast();

--- a/playgrounds/react-vite/src/tabs/Collectables.tsx
+++ b/playgrounds/react-vite/src/tabs/Collectables.tsx
@@ -11,8 +11,13 @@ import { useAccount } from 'wagmi';
 import { useMarketplace } from '../lib/MarketplaceContext';
 
 export function Collectibles() {
-	const { collectionAddress, chainId, setCollectibleId, setActiveTab, orderbookKind } =
-		useMarketplace();
+	const {
+		collectionAddress,
+		chainId,
+		setCollectibleId,
+		setActiveTab,
+		orderbookKind,
+	} = useMarketplace();
 	const { address: accountAddress } = useAccount();
 	const {
 		data: collectiblesWithListings,


### PR DESCRIPTION
* Improve balance check for making offer, trigger checking it while switching between different currencies,
* Improve switching chain; If connected via Waas, `walletClient.chain.id` isn't useful. So, I moved switching chain functionality outside of Machine while ensuring it's called when modal opens.
* Fix: avoid showing transaction status modal after token approval execution. 

Note that disability and pending states of CTAs may behave weird. I will tackle this issue on another PR