### PR TITLE
Refactor buy modal and quantity modal to manage appearance of quantity modal

### DIFF
--- a/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -27,6 +27,8 @@ const BuyModalContent = () => {
 	const callbacks = use$(buyModal$.callbacks);
 	const order = use$(buyModal$.state.order);
 	const isOpen = use$(buyModal$.isOpen);
+	const setCheckoutModalIsLoading = use$(buyModal$.setCheckoutModalIsLoading);
+	const setCheckoutModalLoaded = use$(buyModal$.setCheckoutModalLoaded);
 
 	const { collection, collectable, checkoutOptions, isLoading, isError } =
 		useLoadData({
@@ -47,6 +49,8 @@ const BuyModalContent = () => {
 		callbacks,
 		tokenId: collectibleId,
 		priceCurrencyAddress: order.priceCurrencyAddress,
+		setCheckoutModalIsLoading,
+		setCheckoutModalLoaded,
 	});
 
 	if (

--- a/packages/sdk/src/react/ui/modals/BuyModal/hooks/useBuyCollectable.ts
+++ b/packages/sdk/src/react/ui/modals/BuyModal/hooks/useBuyCollectable.ts
@@ -18,6 +18,8 @@ interface UseBuyCollectableProps {
 	tokenId: string;
 	callbacks?: ModalCallbacks;
 	priceCurrencyAddress: string;
+	setCheckoutModalIsLoading: (isLoading: boolean) => void;
+	setCheckoutModalLoaded: (isLoaded: boolean) => void;
 }
 
 type BuyCollectableReturn =
@@ -42,6 +44,8 @@ export const useBuyCollectable = ({
 	tokenId,
 	callbacks,
 	priceCurrencyAddress,
+	setCheckoutModalIsLoading,
+	setCheckoutModalLoaded,
 }: UseBuyCollectableProps): BuyCollectableReturn => {
 	const { openSelectPaymentModal } = useSelectPaymentModal();
 	const config = useConfig();
@@ -76,6 +80,10 @@ export const useBuyCollectable = ({
 				walletType: WalletKind.unknown,
 			});
 
+			// these states are necessary to manage appearance of the quantity modal
+			setCheckoutModalLoaded(true);
+			setCheckoutModalIsLoading(false);
+
 			const step = steps[0];
 
 			openSelectPaymentModal({
@@ -100,7 +108,6 @@ export const useBuyCollectable = ({
 					callbacks?.onSuccess?.({ hash: hash as Hash }),
 				onError: callbacks?.onError,
 				onClose: () => {
-					console.log('onClose');
 					buyModal$.close();
 				},
 			});

--- a/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
@@ -17,9 +17,6 @@ interface ERC1155QuantityModalProps extends CheckoutModalProps {
 
 export const ERC1155QuantityModal = observer(
 	({ buy, collectable, order }: ERC1155QuantityModalProps) => {
-		buyModal$.state.quantity.set(
-			Math.min(Number(order.quantityRemaining), 1).toString(),
-		);
 		const currencyOptions = useCurrencyOptions({
 			collectionAddress: order.collectionContractAddress as Address,
 		});
@@ -36,6 +33,10 @@ export const ERC1155QuantityModal = observer(
 		const pricePerToken = order.priceAmount;
 		const totalPrice = (BigInt(quantity) * BigInt(pricePerToken)).toString();
 
+		if (buyModal$.state.checkoutModalLoaded.get()) {
+			return null;
+		}
+
 		return (
 			<ActionModal
 				isOpen={buyModal$.isOpen.get()}
@@ -46,6 +47,8 @@ export const ERC1155QuantityModal = observer(
 					{
 						label: 'Buy now',
 						onClick: () => {
+							buyModal$.state.checkoutModalIsLoading.set(true);
+
 							buy({
 								quantity: parseUnits(
 									buyModal$.state.quantity.get(),
@@ -56,6 +59,8 @@ export const ERC1155QuantityModal = observer(
 								marketplace: order.marketplace,
 							});
 						},
+						disabled: buyModal$.state.checkoutModalIsLoading.get(),
+						pending: buyModal$.state.checkoutModalIsLoading.get(),
 					},
 				]}
 			>

--- a/packages/sdk/src/react/ui/modals/BuyModal/store.ts
+++ b/packages/sdk/src/react/ui/modals/BuyModal/store.ts
@@ -17,7 +17,11 @@ export interface BuyModalState {
 		quantity: string;
 		modalId: number;
 		invalidQuantity: boolean;
+		checkoutModalIsLoading: boolean;
+		checkoutModalLoaded: boolean;
 	};
+	setCheckoutModalIsLoading: (isLoading: boolean) => void;
+	setCheckoutModalLoaded: (isLoaded: boolean) => void;
 	callbacks?: ModalCallbacks;
 }
 
@@ -36,6 +40,8 @@ export const initialState: BuyModalState = {
 			order: args.order,
 			modalId: buyModal$.state.modalId.get() + 1,
 			invalidQuantity: false,
+			checkoutModalIsLoading: false,
+			checkoutModalLoaded: false,
 		});
 		buyModal$.callbacks.set(callbacks || defaultCallbacks);
 		buyModal$.isOpen.set(true);
@@ -48,6 +54,14 @@ export const initialState: BuyModalState = {
 		quantity: '1',
 		modalId: 0,
 		invalidQuantity: false,
+		checkoutModalIsLoading: false,
+		checkoutModalLoaded: false,
+	},
+	setCheckoutModalIsLoading: (isLoading: boolean) => {
+		buyModal$.state.checkoutModalIsLoading.set(isLoading);
+	},
+	setCheckoutModalLoaded: (isLoaded: boolean) => {
+		buyModal$.state.checkoutModalLoaded.set(isLoaded);
 	},
 	callbacks: undefined,
 };

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
@@ -142,7 +142,7 @@ const Modal = observer(() => {
 				insufficientBalance ||
 				isLoading ||
 				invalidQuantity ||
-				invalidCurrency
+				invalidCurrency,
 		},
 	];
 

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/hooks/usePriceInput.ts
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/hooks/usePriceInput.ts
@@ -33,9 +33,9 @@ export const usePriceInput = ({
 	}, [currencyDecimals, value, price$]);
 
 	const handlePriceChange = (newValue: string) => {
-		setValue(newValue);  
-		
-              try {
+		setValue(newValue);
+
+		try {
 			const parsedAmount = parseUnits(newValue, Number(currencyDecimals));
 			price$.amountRaw.set(parsedAmount.toString());
 

--- a/packages/sdk/src/react/ui/modals/_internal/components/quantityInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/quantityInput/index.tsx
@@ -101,7 +101,7 @@ export default function QuantityInput({
 						marginRight={'2'}
 					>
 						<IconButton
-							disabled={!quantity || Number(quantity) <= 0}
+							disabled={!quantity || Number(quantity) <= 1}
 							onClick={handleDecrement}
 							background={'buttonGlass'}
 							size="xs"
@@ -109,6 +109,7 @@ export default function QuantityInput({
 						/>
 
 						<IconButton
+							disabled={!quantity || Number(quantity) >= Number(maxQuantity)}
 							onClick={handleIncrement}
 							background={'buttonGlass'}
 							size="xs"

--- a/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
@@ -63,7 +63,7 @@ const SwitchChainModal = observer(() => {
 	return (
 		<Root open={switchChainModal$.isOpen.get()}>
 			<Portal container={getProviderEl()}>
-				<Overlay className={dialogOverlay}  />
+				<Overlay className={dialogOverlay} />
 
 				<Content className={switchChainModalContent}>
 					<Text fontSize="large" fontWeight="bold" color="text100">


### PR DESCRIPTION
This PR is for resolving [this issue](https://github.com/0xsequence/issue-tracker/issues/3098#issuecomment-2592274046) and ([duplicate issue](https://github.com/0xsequence/issue-tracker/issues/3964))

We need to introduce more states for `loading` and `loaded` states of purchase modal to improve ux and unused renders.