### PR TITLE
Dont throw error if error occurs

### DIFF
--- a/packages/sdk/src/react/hooks/useCancelTransactionSteps.tsx
+++ b/packages/sdk/src/react/hooks/useCancelTransactionSteps.tsx
@@ -99,7 +99,6 @@ export const useCancelTransactionSteps = ({
 			} else {
 				console.debug('onError callback not provided:', error);
 			}
-			throw error;
 		}
 	};
 
@@ -180,8 +179,6 @@ export const useCancelTransactionSteps = ({
 			if (onError && typeof onError === 'function') {
 				onError(error as Error);
 			}
-
-			throw error;
 		}
 	};
 

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
@@ -77,7 +77,6 @@ export const useTransactionSteps = ({
 			} else {
 				console.debug('onError callback not provided:', error);
 			}
-			throw error;
 		}
 	};
 
@@ -103,7 +102,6 @@ export const useTransactionSteps = ({
 			}
 		} catch (error) {
 			steps$.approval.isExecuting.set(false);
-			throw error;
 		}
 	};
 
@@ -173,7 +171,6 @@ export const useTransactionSteps = ({
 			if (callbacks?.onError && typeof callbacks.onError === 'function') {
 				callbacks.onError(error as Error);
 			}
-			throw error;
 		}
 	};
 

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
@@ -80,7 +80,6 @@ export const useTransactionSteps = ({
 			} else {
 				console.debug('onError callback not provided:', error);
 			}
-			throw error;
 		}
 	};
 
@@ -106,7 +105,6 @@ export const useTransactionSteps = ({
 			}
 		} catch (error) {
 			steps$.approval.isExecuting.set(false);
-			throw error;
 		}
 	};
 
@@ -178,7 +176,6 @@ export const useTransactionSteps = ({
 			if (callbacks?.onError && typeof callbacks.onError === 'function') {
 				callbacks.onError(error as Error);
 			}
-			throw error;
 		}
 	};
 

--- a/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
@@ -85,7 +85,6 @@ export const useTransactionSteps = ({
 			} else {
 				console.debug('onError callback not provided:', error);
 			}
-			throw error;
 		}
 	};
 
@@ -111,7 +110,6 @@ export const useTransactionSteps = ({
 			}
 		} catch (error) {
 			steps$.approval.isExecuting.set(false);
-			throw error;
 		}
 	};
 
@@ -180,8 +178,6 @@ export const useTransactionSteps = ({
 			if (callbacks?.onError && typeof callbacks.onError === 'function') {
 				callbacks.onError(error as Error);
 			}
-
-			throw error;
 		}
 	};
 

--- a/playgrounds/react-vite/src/components/collectible/ListingsTable.tsx
+++ b/playgrounds/react-vite/src/components/collectible/ListingsTable.tsx
@@ -54,10 +54,11 @@ export const ListingsTable = () => {
 		},
 		onError: (error) => {
 			toast({
-				title: 'Error',
+				title: 'An error occurred cancelling the order',
 				variant: 'error',
-				description: error.message,
+				description: 'See console for more details',
 			});
+			console.error(error);
 		},
 	});
 
@@ -71,10 +72,11 @@ export const ListingsTable = () => {
 		},
 		onError: (error) => {
 			toast({
-				title: 'Error',
+				title: 'An error occurred buying the collectible',
 				variant: 'error',
-				description: error.message,
+				description: 'See console for more details',
 			});
+			console.error(error);
 		},
 	});
 

--- a/playgrounds/react-vite/src/components/collectible/OffersTable.tsx
+++ b/playgrounds/react-vite/src/components/collectible/OffersTable.tsx
@@ -53,10 +53,11 @@ export const OffersTable = () => {
 		},
 		onError: (error) => {
 			toast({
-				title: 'Error',
+				title: 'An error occurred cancelling the order',
 				variant: 'error',
-				description: error.message,
+				description: 'See console for more details',
 			});
+			console.error(error);
 		},
 	});
 
@@ -70,10 +71,11 @@ export const OffersTable = () => {
 		},
 		onError: (error) => {
 			toast({
-				title: 'Error',
+				title: 'An error occurred selling the collectible',
 				variant: 'error',
-				description: error.message,
+				description: 'See console for more details',
 			});
+			console.error(error);
 		},
 	});
 


### PR DESCRIPTION
Currently we throw errors that are needed to be caught where hooks are used. No need to throw them since we already use `onError` callbacks.