### PR TITLE
Manage query client state

### DIFF
--- a/packages/sdk/src/react/_internal/api/get-query-client.ts
+++ b/packages/sdk/src/react/_internal/api/get-query-client.ts
@@ -2,6 +2,7 @@ import {
 	QueryClient,
 	defaultShouldDehydrateQuery,
 } from '@tanstack/react-query';
+import { useState } from 'react';
 import { hashFn } from 'wagmi/query';
 
 function makeQueryClient() {
@@ -29,4 +30,9 @@ export function getQueryClient() {
 
 	if (!browserQueryClient) browserQueryClient = makeQueryClient();
 	return browserQueryClient;
+}
+
+export function useMarketplaceQueryClient() {
+	const [queryClient] = useState(getQueryClient);
+	return queryClient;
 }

--- a/packages/sdk/src/react/_internal/api/get-query-client.ts
+++ b/packages/sdk/src/react/_internal/api/get-query-client.ts
@@ -2,7 +2,6 @@ import {
 	QueryClient,
 	defaultShouldDehydrateQuery,
 } from '@tanstack/react-query';
-import { useState } from 'react';
 import { hashFn } from 'wagmi/query';
 
 function makeQueryClient() {
@@ -30,9 +29,4 @@ export function getQueryClient() {
 
 	if (!browserQueryClient) browserQueryClient = makeQueryClient();
 	return browserQueryClient;
-}
-
-export function useMarketplaceQueryClient() {
-	const [queryClient] = useState(getQueryClient);
-	return queryClient;
 }

--- a/packages/sdk/src/react/hooks/useCancelTransactionSteps.tsx
+++ b/packages/sdk/src/react/hooks/useCancelTransactionSteps.tsx
@@ -1,6 +1,7 @@
 import {
 	ExecuteType,
 	getMarketplaceClient,
+	getQueryClient,
 	MarketplaceKind,
 	Step,
 	StepType,
@@ -109,6 +110,7 @@ export const useCancelTransactionSteps = ({
 		orderId: string;
 		marketplace: MarketplaceKind;
 	}) => {
+		const queryClient = getQueryClient();
 		if (!walletIsInitialized) {
 			throw new WalletInstanceNotFoundError();
 		}
@@ -151,6 +153,8 @@ export const useCancelTransactionSteps = ({
 						onSuccess({ hash });
 					}
 
+					queryClient.invalidateQueries();
+
 					setSteps((prev) => ({
 						...prev,
 						isExecuting: false,
@@ -164,6 +168,8 @@ export const useCancelTransactionSteps = ({
 				if (onSuccess && typeof onSuccess === 'function') {
 					onSuccess({ orderId: reservoirOrderId });
 				}
+
+				queryClient.invalidateQueries();
 
 				setSteps((prev) => ({
 					...prev,

--- a/packages/sdk/src/react/hooks/useCurrency.tsx
+++ b/packages/sdk/src/react/hooks/useCurrency.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, queryOptions, useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import type { SdkConfig } from '../../types';
 import {
@@ -9,7 +9,7 @@ import {
 	QueryArgSchema,
 	currencyKeys,
 	getMarketplaceClient,
-	useMarketplaceQueryClient,
+	getQueryClient,
 } from '../_internal';
 import { useConfig } from './useConfig';
 
@@ -29,9 +29,9 @@ const fetchCurrency = async (
 	chainId: ChainId,
 	currencyAddress: string,
 	config: SdkConfig,
-	queryClient: QueryClient,
 ): Promise<Currency | undefined> => {
 	const parsedChainId = ChainIdCoerce.parse(chainId);
+	const queryClient = getQueryClient();
 
 	let currencies = queryClient.getQueryData([...currencyKeys.lists, chainId]) as
 		| Currency[]
@@ -50,21 +50,15 @@ const fetchCurrency = async (
 	);
 };
 
-export const currencyOptions = (
-	args: UseCurrencyArgs,
-	config: SdkConfig,
-	queryClient: QueryClient,
-) => {
+export const currencyOptions = (args: UseCurrencyArgs, config: SdkConfig) => {
 	return queryOptions({
 		...args.query,
 		queryKey: [...currencyKeys.details, args.chainId, args.currencyAddress],
-		queryFn: () =>
-			fetchCurrency(args.chainId, args.currencyAddress, config, queryClient),
+		queryFn: () => fetchCurrency(args.chainId, args.currencyAddress, config),
 	});
 };
 
 export const useCurrency = (args: UseCurrencyArgs) => {
 	const config = useConfig();
-	const queryClient = useMarketplaceQueryClient();
-	return useQuery(currencyOptions(args, config, queryClient));
+	return useQuery(currencyOptions(args, config));
 };

--- a/packages/sdk/src/react/provider.tsx
+++ b/packages/sdk/src/react/provider.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { QueryClientProvider } from '@tanstack/react-query';
 import { createContext } from 'react';
 import '@0xsequence/design-system/styles.css';
 import type { SdkConfig } from '../types';
 import { PROVIDER_ID } from './_internal/get-provider';
+import { getQueryClient } from './_internal/api/get-query-client';
 
 export const MarketplaceSdkContext = createContext({} as SdkConfig);
 
@@ -12,13 +14,26 @@ export type MarketplaceSdkProviderProps = {
 	children: React.ReactNode;
 };
 
+export function MarketplaceQueryClientProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const queryClient = getQueryClient();
+	return (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}
+
 export function MarketplaceProvider({
 	config,
 	children,
 }: MarketplaceSdkProviderProps) {
 	return (
-		<MarketplaceSdkContext.Provider value={config}>
-			<div id={PROVIDER_ID}>{children}</div>
-		</MarketplaceSdkContext.Provider>
+		<MarketplaceQueryClientProvider>
+			<MarketplaceSdkContext.Provider value={config}>
+				<div id={PROVIDER_ID}>{children}</div>
+			</MarketplaceSdkContext.Provider>
+		</MarketplaceQueryClientProvider>
 	);
 }

--- a/packages/sdk/src/react/ssr/create-ssr-client.ts
+++ b/packages/sdk/src/react/ssr/create-ssr-client.ts
@@ -1,30 +1,34 @@
 import { type State, cookieToInitialState } from 'wagmi';
 import type { SdkConfig } from '../../types/sdk-config';
-import { getQueryClient } from '../_internal/api/get-query-client';
 import { createWagmiConfig } from '../_internal/wagmi/create-config';
 import { marketplaceConfigOptions } from '../hooks/options/marketplaceConfigOptions';
+import { QueryClient } from '@tanstack/react-query';
 
 type InitSSRClientArgs = {
 	cookie: string;
 	config: SdkConfig;
+	queryClient: QueryClient;
 };
 
 type InitialState = { wagmi?: State };
 
-const marketplaceConfig = async (config: SdkConfig) => {
-	const queryClient = getQueryClient();
+const marketplaceConfig = async (
+	config: SdkConfig,
+	queryClient: QueryClient,
+) => {
 	const configOptions = marketplaceConfigOptions(config);
 	return queryClient.fetchQuery(configOptions);
 };
 
 const initialState = async (args: InitSSRClientArgs): Promise<InitialState> => {
-	const marketConfig = await marketplaceConfig(args.config);
+	const marketConfig = await marketplaceConfig(args.config, args.queryClient);
 	const wagmiConfig = createWagmiConfig(marketConfig, args.config, true);
 	return { wagmi: cookieToInitialState(wagmiConfig, args.cookie) };
 };
 
 export const createSSRClient = (args: InitSSRClientArgs) => {
-	const getMarketplaceConfig = async () => marketplaceConfig(args.config);
+	const getMarketplaceConfig = async () =>
+		marketplaceConfig(args.config, args.queryClient);
 	const getInitialState = async () => initialState(args);
 	const config = args.config;
 	return { getInitialState, getMarketplaceConfig, config };

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
@@ -6,6 +6,8 @@ import {
 	type Step,
 	StepType,
 	type TransactionSteps,
+	balanceQueries,
+	collectableKeys,
 	getMarketplaceClient,
 } from '../../../../_internal';
 import {
@@ -145,6 +147,13 @@ export const useTransactionSteps = ({
 				hash,
 				orderId,
 				callbacks,
+				queriesToInvalidate: [
+					balanceQueries.all,
+					collectableKeys.lowestListings,
+					collectableKeys.listings,
+					collectableKeys.listingsCount,
+					collectableKeys.userBalances,
+				],
 			});
 
 			if (hash) {

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
@@ -6,6 +6,8 @@ import {
 	type Step,
 	StepType,
 	type TransactionSteps,
+	balanceQueries,
+	collectableKeys,
 	getMarketplaceClient,
 } from '../../../../_internal';
 import {
@@ -148,6 +150,13 @@ export const useTransactionSteps = ({
 				hash,
 				orderId,
 				callbacks,
+				queriesToInvalidate: [
+					balanceQueries.all,
+					collectableKeys.highestOffers,
+					collectableKeys.offers,
+					collectableKeys.offersCount,
+					collectableKeys.userBalances,
+				],
 			});
 
 			if (hash) {

--- a/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
@@ -1,4 +1,6 @@
 import {
+	balanceQueries,
+	collectableKeys,
 	ExecuteType,
 	getMarketplaceClient,
 	MarketplaceKind,
@@ -151,6 +153,7 @@ export const useTransactionSteps = ({
 				hash,
 				orderId,
 				callbacks,
+				queriesToInvalidate: [balanceQueries.all, collectableKeys.userBalances],
 			});
 
 			if (hash) {

--- a/playgrounds/react-vite/src/lib/provider.tsx
+++ b/playgrounds/react-vite/src/lib/provider.tsx
@@ -7,12 +7,13 @@ import { KitCheckoutProvider } from '@0xsequence/kit-checkout';
 import type { MarketplaceConfig, SdkConfig } from '@0xsequence/marketplace-sdk';
 import {
 	MarketplaceProvider,
+	MarketplaceQueryClientProvider,
 	ModalProvider,
 	createWagmiConfig,
+	getQueryClient,
 	marketplaceConfigOptions,
-	useMarketplaceQueryClient,
 } from '@0xsequence/marketplace-sdk/react';
-import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { type State, WagmiProvider } from 'wagmi';
 import {
@@ -37,7 +38,7 @@ export default function Providers({ children }: ProvidersProps) {
 
 function ConfigurationProvider({ children }: ProvidersProps) {
 	const { sdkConfig } = useMarketplace();
-	const queryClient = useMarketplaceQueryClient();
+	const queryClient = getQueryClient();
 	const { data: marketplaceConfig, isLoading } = useQuery(
 		marketplaceConfigOptions(sdkConfig),
 		queryClient,
@@ -70,7 +71,6 @@ const ApplicationProviders = ({
 	config: SdkConfig;
 	marketplaceConfig: MarketplaceConfig;
 }) => {
-	const queryClient = useMarketplaceQueryClient();
 	const kitConfig: KitConfig = {
 		projectAccessKey: config.projectAccessKey,
 		signIn: {
@@ -87,7 +87,7 @@ const ApplicationProviders = ({
 	return (
 		<ThemeProvider>
 			<WagmiProvider config={wagmiConfig} initialState={initialState?.wagmi}>
-				<QueryClientProvider client={queryClient}>
+				<MarketplaceQueryClientProvider>
 					<KitProvider config={kitConfig}>
 						<KitCheckoutProvider>
 							<ToastProvider>
@@ -99,7 +99,7 @@ const ApplicationProviders = ({
 							</ToastProvider>
 						</KitCheckoutProvider>
 					</KitProvider>
-				</QueryClientProvider>
+				</MarketplaceQueryClientProvider>
 			</WagmiProvider>
 		</ThemeProvider>
 	);

--- a/playgrounds/react-vite/src/lib/provider.tsx
+++ b/playgrounds/react-vite/src/lib/provider.tsx
@@ -9,8 +9,8 @@ import {
 	MarketplaceProvider,
 	ModalProvider,
 	createWagmiConfig,
-	getQueryClient,
 	marketplaceConfigOptions,
+	useMarketplaceQueryClient,
 } from '@0xsequence/marketplace-sdk/react';
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -19,8 +19,6 @@ import {
 	MarketplaceProvider as PlaygroundProvider,
 	useMarketplace,
 } from './MarketplaceContext';
-
-const queryClient = getQueryClient();
 
 interface ProvidersProps {
 	children: React.ReactNode;
@@ -39,7 +37,7 @@ export default function Providers({ children }: ProvidersProps) {
 
 function ConfigurationProvider({ children }: ProvidersProps) {
 	const { sdkConfig } = useMarketplace();
-
+	const queryClient = useMarketplaceQueryClient();
 	const { data: marketplaceConfig, isLoading } = useQuery(
 		marketplaceConfigOptions(sdkConfig),
 		queryClient,
@@ -72,6 +70,7 @@ const ApplicationProviders = ({
 	config: SdkConfig;
 	marketplaceConfig: MarketplaceConfig;
 }) => {
+	const queryClient = useMarketplaceQueryClient();
 	const kitConfig: KitConfig = {
 		projectAccessKey: config.projectAccessKey,
 		signIn: {


### PR DESCRIPTION
We weren't able to invalidate queries that subscribed to the query client somehow. Using `MarketplaceQueryClientProvider` fixes it. 
* Refactor transaction execution of transfer modal, remove duplicate implementations
* Set `queriesToInvalidate` to `showTransactionStatusModal` of related transactions `useTransactionSteps`