### PR TITLE
useCurrencies: replace toHex with Address type for contractAddress filtering

### DIFF
--- a/packages/sdk/src/react/hooks/useCurrencies.tsx
+++ b/packages/sdk/src/react/hooks/useCurrencies.tsx
@@ -1,5 +1,5 @@
 import { queryOptions, useQuery } from '@tanstack/react-query';
-import { toHex, zeroAddress } from 'viem';
+import { Address, zeroAddress } from 'viem';
 import { z } from 'zod';
 import type { SdkConfig } from '../../types';
 import { InvalidCurrencyOptionsError } from '../../utils/_internal/error/transaction';
@@ -49,7 +49,9 @@ const selectCurrencies = (data: Currency[], args: UseCurrenciesArgs) => {
 
 		return data.filter(
 			(currency) =>
-				argsParsed.currencyOptions?.includes(toHex(currency.contractAddress)) ||
+				argsParsed.currencyOptions!.includes(
+					currency.contractAddress as Address,
+				) ||
 				// biome-ignore lint/suspicious/noDoubleEquals: <explanation>
 				currency.nativeCurrency == argsParsed.includeNativeCurrency ||
 				currency.defaultChainCurrency,

--- a/packages/sdk/src/react/hooks/useCurrencies.tsx
+++ b/packages/sdk/src/react/hooks/useCurrencies.tsx
@@ -46,11 +46,14 @@ const selectCurrencies = (data: Currency[], args: UseCurrenciesArgs) => {
 		if (!argsParsed.currencyOptions) {
 			throw new InvalidCurrencyOptionsError(argsParsed.currencyOptions);
 		}
+		const lowerCaseCurrencyOptions = argsParsed.currencyOptions.map((option) =>
+			option.toLowerCase(),
+		);
 
 		return data.filter(
 			(currency) =>
-				argsParsed.currencyOptions!.includes(
-					currency.contractAddress as Address,
+				lowerCaseCurrencyOptions.includes(
+					currency.contractAddress.toLowerCase(),
 				) ||
 				// biome-ignore lint/suspicious/noDoubleEquals: <explanation>
 				currency.nativeCurrency == argsParsed.includeNativeCurrency ||


### PR DESCRIPTION
using `toHex` while comparing is misleading, as it converts `0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582` to `0x307834316539346562303139633037363266396266636639666231653538373235626662306537353832`