### PR TITLE
remove duplicate calls of onSuccess in `useTransactionSteps`

### DIFF
--- a/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useTransactionSteps.tsx
@@ -154,18 +154,11 @@ export const useTransactionSteps = ({
 
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ hash });
-				}
 			}
 
 			if (orderId) {
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ orderId });
-				}
 			}
 		} catch (error) {
 			steps$.transaction.isExecuting.set(false);

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useTransactionSteps.tsx
@@ -165,9 +165,6 @@ export const useTransactionSteps = ({
 
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ hash });
-				}
 			}
 
 			if (orderId) {
@@ -175,10 +172,6 @@ export const useTransactionSteps = ({
 
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ orderId });
-				}
 			}
 		} catch (error) {
 			steps$.transaction.isExecuting.set(false);

--- a/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/hooks/useTransactionSteps.tsx
@@ -155,9 +155,6 @@ export const useTransactionSteps = ({
 				await wallet.handleConfirmTransactionStep(hash, Number(chainId));
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ hash });
-				}
 			}
 
 			if (orderId) {
@@ -165,10 +162,6 @@ export const useTransactionSteps = ({
 
 				steps$.transaction.isExecuting.set(false);
 				steps$.transaction.exist.set(false);
-
-				if (callbacks?.onSuccess && typeof callbacks.onSuccess === 'function') {
-					callbacks.onSuccess({ orderId });
-				}
 			}
 		} catch (error) {
 			steps$.transaction.isExecuting.set(false);


### PR DESCRIPTION
https://github.com/0xsequence/issue-tracker/issues/4010

We already use `onSuccess` callback on `TransactionStatusModal` , no need to use it in `useTransactionSteps`s of transactions