### PR TITLE
4079 - Add tests for createWagmiConfig

### DIFF
--- a/packages/sdk/src/react/__tests__/provider.test.tsx
+++ b/packages/sdk/src/react/__tests__/provider.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarketplaceProvider, MarketplaceSdkContext } from '../provider';
+import { useContext } from 'react';
+import { InvalidProjectAccessKeyError } from '../../utils/_internal/error/config';
+import type { SdkConfig } from '../../types';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);
+
+// Test component to verify context value
+function TestComponent() {
+	const config = useContext(MarketplaceSdkContext);
+	return <div data-testid="config-value">{config.projectAccessKey}</div>;
+}
+
+describe('MarketplaceProvider', () => {
+	let baseSdkConfig: SdkConfig;
+
+	beforeEach(() => {
+		baseSdkConfig = {
+			projectAccessKey: 'test-access-key',
+			projectId: '1',
+		};
+	});
+
+	it('should throw error when projectAccessKey is empty', () => {
+		const invalidConfig: SdkConfig = {
+			...baseSdkConfig,
+			projectAccessKey: '',
+		};
+
+		expect(() =>
+			render(
+				<MarketplaceProvider config={invalidConfig}>
+					<div>Test</div>
+				</MarketplaceProvider>,
+			),
+		).toThrow(InvalidProjectAccessKeyError);
+	});
+
+	it('should render children when config is valid', () => {
+		const testMessage = 'Test Content';
+		const { getByText } = render(
+			<MarketplaceProvider config={baseSdkConfig}>
+				<div>{testMessage}</div>
+			</MarketplaceProvider>,
+		);
+
+		expect(getByText(testMessage)).toBeInTheDocument();
+	});
+
+	it('should provide config through context', () => {
+		render(
+			<MarketplaceProvider config={baseSdkConfig}>
+				<TestComponent />
+			</MarketplaceProvider>,
+		);
+
+		expect(screen.getByTestId('config-value')).toHaveTextContent(
+			baseSdkConfig.projectAccessKey,
+		);
+	});
+
+	it('should render with provider ID', () => {
+		const { container } = render(
+			<MarketplaceProvider config={baseSdkConfig}>
+				<div>Test</div>
+			</MarketplaceProvider>,
+		);
+
+		const providerElement = container.querySelector('#sdk-provider');
+		expect(providerElement).toBeInTheDocument();
+	});
+});

--- a/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
+++ b/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
@@ -5,6 +5,7 @@ import type { MarketplaceConfig, SdkConfig } from '../../../../types';
 import { WalletOptions } from '../../../../types';
 import { polygon } from 'viem/chains';
 import { MissingConfigError } from '../../../../utils/_internal/error/transaction';
+import { cookieStorage, type Config } from 'wagmi';
 
 describe('createWagmiConfig', () => {
 	let baseMarketplaceConfig: MarketplaceConfig;
@@ -120,14 +121,23 @@ describe('createWagmiConfig', () => {
 			expect(config.chains).toHaveLength(1);
 		});
 
-		it('should create SSR compatible config when ssr flag is true', () => {
+		it('should create SSR compatible config when ssr flag is true', async () => {
 			const config = createWagmiConfig(
 				baseMarketplaceConfig,
 				baseSdkConfig,
 				true,
-			);
-			expect(config.storage).toBeDefined();
-			expect(config.chains).toHaveLength(1);
+			) as Config;
+
+			expect(config.storage).toBeInstanceOf(cookieStorage.constructor);
+
+			const testKey = 'wagmi.test';
+			const testValue = { data: 'test-value' };
+
+			config.storage?.setItem(testKey, JSON.stringify(testValue));
+
+			const storedValue = await config.storage?.getItem(testKey);
+			expect(storedValue).toBeDefined();
+			expect(JSON.parse(storedValue as string)).toEqual(testValue);
 		});
 	});
 

--- a/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
+++ b/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createWagmiConfig } from '../create-config';
+import { getWaasConnectors } from '../embedded';
+import type { MarketplaceConfig, SdkConfig } from '../../../../types';
+import { WalletOptions } from '../../../../types';
+import { polygon } from 'viem/chains';
+import { MissingConfigError } from '../../../../utils/_internal/error/transaction';
+
+describe('createWagmiConfig', () => {
+	let baseMarketplaceConfig: MarketplaceConfig;
+	let baseSdkConfig: SdkConfig;
+
+	beforeEach(() => {
+		baseMarketplaceConfig = {
+			projectId: 1,
+			publisherId: 'test-publisher',
+			title: 'Test Marketplace',
+			shortDescription: 'Test Description',
+			faviconUrl: 'https://test.com/favicon.ico',
+			landingBannerUrl: 'https://test.com/banner.jpg',
+			titleTemplate: '%s | Test',
+			walletOptions: [WalletOptions.Sequence],
+			collections: [
+				{
+					collectionAddress: '0x1234567890123456789012345678901234567890',
+					chainId: polygon.id,
+					marketplaceFeePercentage: 2.5,
+					marketplaceType: 'orderbook',
+				},
+			],
+			landingPageLayout: 'default',
+			cssString: '',
+			manifestUrl: 'https://test.com/manifest.json',
+		};
+
+		baseSdkConfig = {
+			projectAccessKey: 'test-access-key',
+			projectId: '1',
+		};
+	});
+
+	describe('successful cases', () => {
+		it('should create config with empty collections', () => {
+			const configWithEmptyCollections = createWagmiConfig(
+				{
+					...baseMarketplaceConfig,
+					collections: [],
+				},
+				baseSdkConfig,
+			);
+			expect(configWithEmptyCollections.chains).toBeDefined();
+			expect(Array.isArray(configWithEmptyCollections.chains)).toBe(true);
+			expect(configWithEmptyCollections.chains).toHaveLength(1);
+			// Default chain is polygon if no collections are specified
+			expect(configWithEmptyCollections.chains[0].id).toBe(polygon.id);
+		});
+
+		it('should create config with universal wallet setup', () => {
+			const marketplaceConfig: MarketplaceConfig = {
+				...baseMarketplaceConfig,
+				walletOptionsNew: {
+					connectors: ['walletconnect', 'coinbase'],
+					includeEIP6963Wallets: true,
+					walletType: 'universal',
+				},
+			};
+
+			const sdkConfig: SdkConfig = {
+				...baseSdkConfig,
+				wallet: {
+					walletConnectProjectId: 'test-wc-project-id',
+				},
+			};
+
+			const config = createWagmiConfig(marketplaceConfig, sdkConfig);
+			expect(config.connectors).toBeDefined();
+			expect(config.chains).toHaveLength(1);
+		});
+
+		it('should create config with embedded wallet setup', () => {
+			const marketplaceConfig: MarketplaceConfig = {
+				...baseMarketplaceConfig,
+				walletOptionsNew: {
+					connectors: ['walletconnect'],
+					includeEIP6963Wallets: false,
+					walletType: 'embedded',
+				},
+			};
+
+			const sdkConfig: SdkConfig = {
+				...baseSdkConfig,
+				wallet: {
+					embedded: {
+						waasConfigKey:
+							'eyJwcm9qZWN0SWQiOjEzNjM5LCJycGNTZXJ2ZXIiOiJodHRwczovL3dhYXMuc2VxdWVuY2UuYXBwIn0',
+						googleClientId: 'test-google-id',
+						appleClientId: 'test-apple-id',
+						appleRedirectURI: 'https://test.com/redirect',
+					},
+				},
+			};
+
+			const config = createWagmiConfig(marketplaceConfig, sdkConfig);
+			expect(config.connectors).toBeDefined();
+			expect(config.chains).toHaveLength(1);
+		});
+
+		it('should respect EIP6963 wallet inclusion setting', () => {
+			const marketplaceConfig: MarketplaceConfig = {
+				...baseMarketplaceConfig,
+				walletOptionsNew: {
+					connectors: ['walletconnect'],
+					includeEIP6963Wallets: false,
+					walletType: 'universal',
+				},
+			};
+
+			const config = createWagmiConfig(marketplaceConfig, baseSdkConfig);
+			expect(config.connectors).toBeDefined();
+			expect(config.chains).toHaveLength(1);
+		});
+
+		it('should create SSR compatible config when ssr flag is true', () => {
+			const config = createWagmiConfig(
+				baseMarketplaceConfig,
+				baseSdkConfig,
+				true,
+			);
+			expect(config.storage).toBeDefined();
+			expect(config.chains).toHaveLength(1);
+		});
+	});
+
+	describe('failure cases', () => {
+		it('should throw error when trying to use embedded wallet without waasConfigKey', () => {
+			const marketplaceConfig: MarketplaceConfig = {
+				...baseMarketplaceConfig,
+				walletOptionsNew: {
+					connectors: ['walletconnect'],
+					includeEIP6963Wallets: false,
+					walletType: 'embedded',
+				},
+			};
+
+			const sdkConfig: SdkConfig = {
+				...baseSdkConfig,
+				wallet: {
+					embedded: {
+						waasConfigKey: '',
+						googleClientId: 'test-google-id',
+						appleClientId: 'test-apple-id',
+						appleRedirectURI: 'https://test.com/redirect',
+					},
+				},
+			};
+
+			expect(() =>
+				getWaasConnectors(marketplaceConfig, {
+					...sdkConfig,
+					wallet: {
+						...sdkConfig.wallet,
+						embedded: {
+							...sdkConfig.wallet?.embedded,
+							waasConfigKey: '', // Empty waasConfigKey should trigger the error
+						},
+					},
+				}),
+			).toThrow(MissingConfigError);
+		});
+
+		it('should still create config when walletConnectProjectId is missing', () => {
+			const marketplaceConfig: MarketplaceConfig = {
+				...baseMarketplaceConfig,
+				walletOptionsNew: {
+					connectors: ['walletconnect'],
+					includeEIP6963Wallets: true,
+					walletType: 'universal',
+				},
+			};
+
+			const config = createWagmiConfig(marketplaceConfig, baseSdkConfig);
+			expect(config.connectors).toBeDefined();
+			expect(config.chains).toHaveLength(1);
+		});
+
+		it('should still create config when projectAccessKey is empty', () => {
+			const sdkConfig: SdkConfig = {
+				...baseSdkConfig,
+				projectAccessKey: '', // Empty project access key
+			};
+
+			const config = createWagmiConfig(baseMarketplaceConfig, sdkConfig);
+			expect(config.chains).toHaveLength(1);
+		});
+	});
+});

--- a/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
+++ b/packages/sdk/src/react/_internal/wagmi/__tests__/create-config.test.ts
@@ -192,15 +192,5 @@ describe('createWagmiConfig', () => {
 			expect(config.connectors).toBeDefined();
 			expect(config.chains).toHaveLength(1);
 		});
-
-		it('should still create config when projectAccessKey is empty', () => {
-			const sdkConfig: SdkConfig = {
-				...baseSdkConfig,
-				projectAccessKey: '', // Empty project access key
-			};
-
-			const config = createWagmiConfig(baseMarketplaceConfig, sdkConfig);
-			expect(config.chains).toHaveLength(1);
-		});
 	});
 });

--- a/packages/sdk/src/react/_internal/wagmi/create-config.ts
+++ b/packages/sdk/src/react/_internal/wagmi/create-config.ts
@@ -1,6 +1,7 @@
 import { getDefaultChains } from '@0xsequence/kit';
 import { allNetworks, findNetworkConfig } from '@0xsequence/network';
 import type { Chain, Transport } from 'viem';
+import { polygon } from 'viem/chains';
 import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
 import type { MarketplaceConfig, SdkConfig } from '../../../types';
 import { getWaasConnectors } from './embedded';
@@ -45,7 +46,14 @@ function getChainConfigs(marketConfig: MarketplaceConfig): [Chain, ...Chain[]] {
 	const supportedChainIds = new Set(
 		marketConfig.collections.map((c) => c.chainId),
 	);
-	return getDefaultChains([...supportedChainIds]);
+
+	// Marketplace config does not specify any chains, use polygon as default
+	if (supportedChainIds.size === 0) {
+		supportedChainIds.add(polygon.id); // Mainnet chain ID
+	}
+	const chains = getDefaultChains([...supportedChainIds]);
+
+	return chains;
 }
 
 function getTransportConfigs(

--- a/packages/sdk/src/react/provider.tsx
+++ b/packages/sdk/src/react/provider.tsx
@@ -6,6 +6,7 @@ import '@0xsequence/design-system/styles.css';
 import type { SdkConfig } from '../types';
 import { PROVIDER_ID } from './_internal/get-provider';
 import { getQueryClient } from './_internal/api/get-query-client';
+import { InvalidProjectAccessKeyError } from '../utils/_internal/error/config';
 
 export const MarketplaceSdkContext = createContext({} as SdkConfig);
 
@@ -29,6 +30,10 @@ export function MarketplaceProvider({
 	config,
 	children,
 }: MarketplaceSdkProviderProps) {
+	if (config.projectAccessKey === '' || !config.projectAccessKey) {
+		throw new InvalidProjectAccessKeyError(config.projectAccessKey);
+	}
+
 	return (
 		<MarketplaceQueryClientProvider>
 			<MarketplaceSdkContext.Provider value={config}>

--- a/packages/sdk/src/utils/_internal/error/config.ts
+++ b/packages/sdk/src/utils/_internal/error/config.ts
@@ -1,0 +1,16 @@
+import { BaseError } from './base';
+
+export type ConfigErrorType<name extends string = 'ConfigError'> = BaseError & {
+	name: name;
+};
+
+export class ConfigError extends BaseError {
+	override name = 'ConfigError';
+}
+
+export class InvalidProjectAccessKeyError extends ConfigError {
+	override name = 'InvalidProjectAccessKeyError';
+	constructor(projectAccessKey: string) {
+		super(`Invalid project access key: ${projectAccessKey}`);
+	}
+}

--- a/playgrounds/react-vite/src/lib/provider.tsx
+++ b/playgrounds/react-vite/src/lib/provider.tsx
@@ -52,6 +52,10 @@ function ConfigurationProvider({ children }: ProvidersProps) {
 		return <div>Failed to load marketplace configuration</div>;
 	}
 
+	if (!sdkConfig.projectAccessKey || sdkConfig.projectAccessKey === '') {
+		return <div>Please set a valid project access key</div>;
+	}
+
 	return (
 		<ApplicationProviders
 			config={sdkConfig}

--- a/playgrounds/react-vite/src/tabs/Collections.tsx
+++ b/playgrounds/react-vite/src/tabs/Collections.tsx
@@ -8,7 +8,8 @@ import { ROUTES } from '../lib/routes';
 
 export function Collections() {
 	const navigate = useNavigate();
-	const { data: collections } = useListCollections();
+	const { data: collections, isLoading: collectionsLoading } =
+		useListCollections();
 	const { setChainId, setCollectionAddress } = useMarketplace();
 
 	const handleCollectionClick = (collection: ContractInfo) => {
@@ -16,6 +17,14 @@ export function Collections() {
 		setCollectionAddress(collection.address as Hex);
 		navigate(`/${ROUTES.COLLECTIBLES.path}`);
 	};
+
+	if (collections?.length === 0 && !collectionsLoading) {
+		return (
+			<Box paddingTop="3" display="flex" justifyContent="center">
+				<Text variant="large">No collections found</Text>
+			</Box>
+		);
+	}
 
 	return (
 		<Box


### PR DESCRIPTION
[ISSUE](https://github.com/0xsequence/issue-tracker/issues/4079)

This PR introduces a comprehensive test suite for the createWagmiConfig function, covering both successful and failure scenarios. The tests ensure correct behavior across different wallet configurations and edge cases.

Changes:
	•	Added test cases for creating configs with:
	•	Empty collections (defaulting to Polygon)
	•	Universal wallet setup
	•	Embedded wallet setup
	•	EIP6963 wallet inclusion/exclusion
	•	SSR compatibility
	•	Handling missing waasConfigKey (falling back to universal wallet)
	•	Added failure cases to ensure proper error handling:
	•	Using embedded wallets without a valid waasConfigKey
	•	Creating config without walletConnectProjectId
	•	Creating config with an empty projectAccessKey