### PR TITLE
Fix overlapped purchase flow modals

### DIFF
--- a/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -1,14 +1,14 @@
 import { use$ } from '@legendapp/state/react';
 import type { Hex } from 'viem';
 import { ContractType, type TokenMetadata } from '../../../_internal';
-import { buyModal$ } from './store';
+import { ErrorModal } from '../_internal/components/actionModal/ErrorModal';
 import { LoadingModal } from '../_internal/components/actionModal/LoadingModal';
+import { useBuyCollectable } from './hooks/useBuyCollectable';
+import { useLoadData } from './hooks/useLoadData';
 import { CheckoutModal } from './modals/CheckoutModal';
 import type { BuyInput } from './modals/CheckoutModal';
 import { ERC1155QuantityModal } from './modals/Modal1155';
-import { useLoadData } from './hooks/useLoadData';
-import { useBuyCollectable } from './hooks/useBuyCollectable';
-import { ErrorModal } from '../_internal/components/actionModal/ErrorModal';
+import { buyModal$ } from './store';
 
 export const BuyModal = () => {
 	const isOpen = use$(buyModal$.isOpen);
@@ -57,6 +57,7 @@ const BuyModalContent = () => {
 	const buyAction = (input: BuyInput) => {
 		if (buy && checkoutOptions) {
 			buy({ ...input, checkoutOptions });
+			buyModal$.state.purchaseProcessing.set(true);
 		} else {
 			console.error('buy is null or undefined');
 		}
@@ -89,6 +90,10 @@ const BuyModalContent = () => {
 				title="Error"
 			/>
 		);
+	}
+
+	if (buyModal$.state.purchaseProcessing.get()) {
+		return null;
 	}
 
 	return collection.type === ContractType.ERC721 ? (

--- a/packages/sdk/src/react/ui/modals/BuyModal/__tests__/store.test.ts
+++ b/packages/sdk/src/react/ui/modals/BuyModal/__tests__/store.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { buyModal$, initialState } from '../store';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { Order } from '../../../../_internal';
+import { buyModal$, initialState } from '../store';
 
 describe('BuyModal Store', () => {
 	beforeEach(() => {
@@ -15,6 +15,7 @@ describe('BuyModal Store', () => {
 			invalidQuantity: false,
 			checkoutModalIsLoading: false,
 			checkoutModalLoaded: false,
+			purchaseProcessing: false,
 		});
 		expect(buyModal$.callbacks.get()).toBeUndefined();
 	});
@@ -44,6 +45,7 @@ describe('BuyModal Store', () => {
 			invalidQuantity: false,
 			checkoutModalIsLoading: false,
 			checkoutModalLoaded: false,
+			purchaseProcessing: false,
 		});
 		expect(buyModal$.callbacks.get()).toBe(mockCallbacks);
 	});

--- a/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
@@ -3,8 +3,8 @@ import { observer } from '@legendapp/state/react';
 import type { Hex } from 'viem';
 import { formatUnits, parseUnits } from 'viem';
 import { useCurrency } from '../../../../hooks';
-import QuantityInput from '../../_internal/components/quantityInput';
 import { ActionModal } from '../../_internal/components/actionModal';
+import QuantityInput from '../../_internal/components/quantityInput';
 import { buyModal$ } from '../store';
 import type { CheckoutModalProps } from './CheckoutModal';
 
@@ -28,7 +28,8 @@ export const ERC1155QuantityModal = observer(
 		if (
 			buyModal$.state.checkoutModalLoaded.get() &&
 			buyModal$.isOpen.get() &&
-			buyModal$.state.checkoutModalIsLoading.get()
+			buyModal$.state.checkoutModalIsLoading.get() &&
+			buyModal$.state.purchaseProcessing.get()
 		) {
 			return null;
 		}
@@ -44,6 +45,7 @@ export const ERC1155QuantityModal = observer(
 						label: 'Buy now',
 						onClick: () => {
 							buyModal$.state.checkoutModalIsLoading.set(true);
+							buyModal$.state.purchaseProcessing.set(true);
 
 							buy({
 								quantity: parseUnits(

--- a/packages/sdk/src/react/ui/modals/BuyModal/store.ts
+++ b/packages/sdk/src/react/ui/modals/BuyModal/store.ts
@@ -9,6 +9,7 @@ const buyState = {
 	invalidQuantity: false,
 	checkoutModalIsLoading: false,
 	checkoutModalLoaded: false,
+	purchaseProcessing: false,
 } as const;
 
 export interface BuyModalState {
@@ -26,9 +27,11 @@ export interface BuyModalState {
 		invalidQuantity: boolean;
 		checkoutModalIsLoading: boolean;
 		checkoutModalLoaded: boolean;
+		purchaseProcessing: boolean;
 	};
 	setCheckoutModalIsLoading: (isLoading: boolean) => void;
 	setCheckoutModalLoaded: (isLoaded: boolean) => void;
+	setPurchaseProcessing: (isProcessing: boolean) => void;
 	callbacks?: ModalCallbacks;
 }
 
@@ -48,6 +51,7 @@ export const initialState: BuyModalState = {
 			invalidQuantity: false,
 			checkoutModalIsLoading: false,
 			checkoutModalLoaded: false,
+			purchaseProcessing: false,
 		});
 		buyModal$.callbacks.set(callbacks || defaultCallbacks);
 		buyModal$.isOpen.set(true);
@@ -63,6 +67,9 @@ export const initialState: BuyModalState = {
 	},
 	setCheckoutModalLoaded: (isLoaded: boolean) => {
 		buyModal$.state.checkoutModalLoaded.set(isLoaded);
+	},
+	setPurchaseProcessing: (isProcessing: boolean) => {
+		buyModal$.state.purchaseProcessing.set(isProcessing);
 	},
 	callbacks: undefined,
 };


### PR DESCRIPTION
https://github.com/0xsequence/issue-tracker/issues/4243#issuecomment-2677845385
Quantity selection modal overlaps the purchase modal. This PR resolves this behavior by not rendering Quantity Modal when purchase is being processed.