### PR TITLE
4285 - Fix incorrect balance

### DIFF
--- a/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
@@ -184,6 +184,7 @@ export function CollectibleCard({
 						lowestListingPriceAmount={lowestListing?.order?.priceAmount}
 						lowestListingCurrency={lowestListingCurrency}
 						balance={balance}
+						decimals={collectibleMetadata?.decimals}
 					/>
 
 					{(highestOffer || lowestListing) && (

--- a/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
@@ -15,6 +15,7 @@ const formatPrice = (amount: string, currency: Currency): string => {
 type FooterProps = {
 	name: string;
 	type?: ContractType;
+	decimals?: number;
 	onOfferClick?: () => void;
 	highestOffer?: Order;
 	lowestListingPriceAmount?: string;
@@ -25,6 +26,7 @@ type FooterProps = {
 export const Footer = ({
 	name,
 	type,
+	decimals,
 	onOfferClick,
 	highestOffer,
 	lowestListingPriceAmount,
@@ -104,7 +106,11 @@ export const Footer = ({
 				</Text>
 			</Box>
 
-			<TokenTypeBalancePill balance={balance} type={type as ContractType} />
+			<TokenTypeBalancePill
+				balance={balance}
+				type={type as ContractType}
+				decimals={decimals}
+			/>
 		</Box>
 	);
 };
@@ -112,14 +118,16 @@ export const Footer = ({
 const TokenTypeBalancePill = ({
 	balance,
 	type,
+	decimals,
 }: {
 	balance?: string;
 	type: ContractType;
+	decimals?: number;
 }) => {
 	const displayText =
 		type === ContractType.ERC1155
 			? balance
-				? `Owned: ${balance}`
+				? `Owned: ${formatUnits(BigInt(balance), decimals ?? 0)}`
 				: 'ERC-1155'
 			: 'ERC-721';
 

--- a/playgrounds/react-vite/src/tabs/Collectables.tsx
+++ b/playgrounds/react-vite/src/tabs/Collectables.tsx
@@ -1,7 +1,8 @@
 import { Text } from '@0xsequence/design-system2';
 import { useCollection } from '@0xsequence/marketplace-sdk/react';
+import type { ContractInfo } from '@0xsequence/metadata';
 import { useNavigate } from 'react-router';
-import type { Collection, OrderbookKind } from '../../../../packages/sdk/src';
+import type { OrderbookKind } from '../../../../packages/sdk/src';
 import { useMarketplace } from '../lib/MarketplaceContext';
 import { ROUTES } from '../lib/routes';
 import { InfiniteScrollView } from './components/InfiniteScrollView';
@@ -41,7 +42,7 @@ export function Collectibles() {
 					collectionAddress={collectionAddress}
 					chainId={chainId}
 					orderbookKind={orderbookKind as OrderbookKind}
-					collection={collection as unknown as Collection}
+					collection={collection as unknown as ContractInfo}
 					collectionLoading={collectionLoading}
 					onCollectibleClick={handleCollectibleClick}
 				/>
@@ -50,7 +51,7 @@ export function Collectibles() {
 					collectionAddress={collectionAddress}
 					chainId={chainId}
 					orderbookKind={orderbookKind as OrderbookKind}
-					collection={collection as unknown as Collection}
+					collection={collection as unknown as ContractInfo}
 					collectionLoading={collectionLoading}
 					onCollectibleClick={handleCollectibleClick}
 				/>

--- a/playgrounds/react-vite/src/tabs/components/InfiniteScrollView.tsx
+++ b/playgrounds/react-vite/src/tabs/components/InfiniteScrollView.tsx
@@ -1,24 +1,19 @@
 import { Text, useToast } from '@0xsequence/design-system2';
-import { useCollectionBalance } from '@0xsequence/kit';
-import {
-	type Collection,
-	type ContractType,
-	OrderSide,
-	type OrderbookKind,
-} from '@0xsequence/marketplace-sdk';
+import { OrderSide, type OrderbookKind } from '@0xsequence/marketplace-sdk';
 import {
 	CollectibleCard,
+	useCollectionBalanceDetails,
 	useListCollectibles,
 } from '@0xsequence/marketplace-sdk/react';
+import type { ContractInfo, ContractType } from '@0xsequence/metadata';
 import React from 'react';
 import { useAccount } from 'wagmi';
 import { CollectibleCardAction } from '../../../../../packages/sdk/src/react/ui/components/_internals/action-button/types';
-
 interface InfiniteScrollViewProps {
 	collectionAddress: `0x${string}`;
 	chainId: string;
 	orderbookKind: OrderbookKind;
-	collection: Collection;
+	collection: ContractInfo;
 	collectionLoading: boolean;
 	onCollectibleClick: (tokenId: string) => void;
 }
@@ -45,11 +40,16 @@ export function InfiniteScrollView({
 	});
 
 	const { data: collectionBalance, isLoading: collectionBalanceLoading } =
-		useCollectionBalance({
-			contractAddress: collectionAddress,
+		useCollectionBalanceDetails({
 			chainId: Number(chainId),
-			accountAddress: accountAddress || '',
-			includeMetadata: false,
+			filter: {
+				accountAddresses: accountAddress ? [accountAddress] : [],
+				omitNativeBalances: true,
+				contractWhitelist: [collectionAddress],
+			},
+			query: {
+				enabled: !!accountAddress,
+			},
 		});
 
 	const toast = useToast();
@@ -87,12 +87,12 @@ export function InfiniteScrollView({
 								chainId={chainId}
 								collectionAddress={collectionAddress}
 								orderbookKind={orderbookKind}
-								collectionType={collection?.contractType as ContractType}
+								collectionType={collection?.type as ContractType}
 								lowestListing={collectibleLowestListing}
 								onCollectibleClick={onCollectibleClick}
 								onOfferClick={({ order }) => console.log(order)}
 								balance={
-									collectionBalance?.find(
+									collectionBalance?.balances.find(
 										(balance) =>
 											balance.tokenID ===
 											collectibleLowestListing.metadata.tokenId,


### PR DESCRIPTION
[Issue](https://github.com/0xsequence/issue-tracker/issues/4285)

We forgot to format balance of wallet for tokens with decimals. This PR fixes it and includes some improvements on typings of `CollectibleCard`
For case Sid has encountered, tokenMetadata for ERC1155s had `decimals=2`, which makes `100` -> `1`
