### PR TITLE
4306 - fix: improve price formatting in collectible card footer

### DIFF
--- a/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
@@ -7,9 +7,19 @@ import { footer, offerBellButton } from './styles.css';
 const formatPrice = (amount: string, currency: Currency): string => {
 	const formattedPrice = formatUnits(BigInt(amount), currency.decimals);
 	const numericPrice = Number.parseFloat(formattedPrice);
-	return numericPrice < 0.0001
-		? `< 0.0001 ${currency.symbol}`
-		: `${formattedPrice} ${currency.symbol}`;
+
+	if (numericPrice < 0.0001) {
+		return `< 0.0001 ${currency.symbol}`;
+	}
+
+	const maxDecimals = numericPrice < 0.01 ? 6 : 4;
+
+	const formattedNumber = numericPrice.toLocaleString('en-US', {
+		minimumFractionDigits: 0,
+		maximumFractionDigits: maxDecimals,
+	});
+
+	return `${formattedNumber} ${currency.symbol}`;
 };
 
 type FooterProps = {


### PR DESCRIPTION
[Issue](https://github.com/0xsequence/issue-tracker/issues/4306)
use `maxDecimals` on `formatPrice`  to manage overflowing prices

![image](https://github.com/user-attachments/assets/3e056935-4295-4b8f-8544-b60fd5030a0b)
