### PR TITLE
don't manipulate balance by formatting it with decimals of token

### DIFF
--- a/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
@@ -184,7 +184,6 @@ export function CollectibleCard({
 						lowestListingPriceAmount={lowestListing?.order?.priceAmount}
 						lowestListingCurrency={lowestListingCurrency}
 						balance={balance}
-						decimals={collectibleMetadata?.decimals}
 					/>
 
 					{(highestOffer || lowestListing) && (

--- a/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
@@ -36,7 +36,6 @@ type FooterProps = {
 export const Footer = ({
 	name,
 	type,
-	decimals,
 	onOfferClick,
 	highestOffer,
 	lowestListingPriceAmount,
@@ -116,11 +115,7 @@ export const Footer = ({
 				</Text>
 			</Box>
 
-			<TokenTypeBalancePill
-				balance={balance}
-				type={type as ContractType}
-				decimals={decimals}
-			/>
+			<TokenTypeBalancePill balance={balance} type={type as ContractType} />
 		</Box>
 	);
 };
@@ -128,16 +123,14 @@ export const Footer = ({
 const TokenTypeBalancePill = ({
 	balance,
 	type,
-	decimals,
 }: {
 	balance?: string;
 	type: ContractType;
-	decimals?: number;
 }) => {
 	const displayText =
 		type === ContractType.ERC1155
 			? balance
-				? `Owned: ${formatUnits(BigInt(balance), decimals ?? 0)}`
+				? `Owned: ${balance}`
 				: 'ERC-1155'
 			: 'ERC-721';
 


### PR DESCRIPTION
[Context](https://sequence-xyz.slack.com/archives/C06HQCL8ML5/p1741162079165209)
We already receive formatted balance, no need to apply `formatUnits` with its decimals.