### PR TITLE
Preserve directives

### DIFF
--- a/packages/sdk/eslint.config.mjs
+++ b/packages/sdk/eslint.config.mjs
@@ -1,0 +1,28 @@
+import pluginJs from '@eslint/js';
+import biome from 'eslint-config-biome';
+import pluginReact from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import rscPlugin from './eslint/use-client.js';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+	{ files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
+	{ languageOptions: { globals: { ...globals.browser, ...globals.node } } },
+	pluginJs.configs.recommended,
+	...tseslint.configs.recommended,
+	pluginReact.configs.flat.recommended,
+	reactHooks.configs['recommended-latest'],
+	rscPlugin.configs.recommended,
+	biome,
+	{
+		rules: {
+			// "react-server-components/use-client": "error",
+			'react/react-in-jsx-scope': 'off',
+			'@typescript-eslint/ban-ts-comment': 'off',
+			'@typescript-eslint/no-unused-vars': 'off',
+			'@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+		},
+	},
+];

--- a/packages/sdk/eslint/use-client.js
+++ b/packages/sdk/eslint/use-client.js
@@ -1,0 +1,454 @@
+/**
+ * ESLint v9 Compatible React Server Components Plugin
+ * Based on https://github.com/roginfarrer/eslint-plugin-react-server-components
+ */
+
+import Components from 'eslint-plugin-react/lib/util/Components.js';
+import componentUtil from 'eslint-plugin-react/lib/util/componentUtil.js';
+import globals from 'globals';
+
+const reactEvents = [
+	'onCopy',
+	'onCopyCapture',
+	'onCut',
+	'onCutCapture',
+	'onPaste',
+	'onPasteCapture',
+	'onCompositionEnd',
+	'onCompositionEndCapture',
+	'onCompositionStart',
+	'onCompositionStartCapture',
+	'onCompositionUpdate',
+	'onCompositionUpdateCapture',
+	'onFocus',
+	'onFocusCapture',
+	'onBlur',
+	'onBlurCapture',
+	'onChange',
+	'onChangeCapture',
+	'onBeforeInput',
+	'onBeforeInputCapture',
+	'onInput',
+	'onInputCapture',
+	'onReset',
+	'onResetCapture',
+	'onSubmit',
+	'onSubmitCapture',
+	'onInvalid',
+	'onInvalidCapture',
+	'onLoad',
+	'onLoadCapture',
+	'onKeyDown',
+	'onKeyDownCapture',
+	'onKeyPress',
+	'onKeyPressCapture',
+	'onKeyUp',
+	'onKeyUpCapture',
+	'onAbort',
+	'onAbortCapture',
+	'onCanPlay',
+	'onCanPlayCapture',
+	'onCanPlayThrough',
+	'onCanPlayThroughCapture',
+	'onDurationChange',
+	'onDurationChangeCapture',
+	'onEmptied',
+	'onEmptiedCapture',
+	'onEncrypted',
+	'onEncryptedCapture',
+	'onEnded',
+	'onEndedCapture',
+	'onLoadedData',
+	'onLoadedDataCapture',
+	'onLoadedMetadata',
+	'onLoadedMetadataCapture',
+	'onLoadStart',
+	'onLoadStartCapture',
+	'onPause',
+	'onPauseCapture',
+	'onPlay',
+	'onPlayCapture',
+	'onPlaying',
+	'onPlayingCapture',
+	'onProgress',
+	'onProgressCapture',
+	'onRateChange',
+	'onRateChangeCapture',
+	'onResize',
+	'onResizeCapture',
+	'onSeeked',
+	'onSeekedCapture',
+	'onSeeking',
+	'onSeekingCapture',
+	'onStalled',
+	'onStalledCapture',
+	'onSuspend',
+	'onSuspendCapture',
+	'onTimeUpdate',
+	'onTimeUpdateCapture',
+	'onVolumeChange',
+	'onVolumeChangeCapture',
+	'onWaiting',
+	'onWaitingCapture',
+	'onAuxClick',
+	'onAuxClickCapture',
+	'onClick',
+	'onClickCapture',
+	'onContextMenu',
+	'onContextMenuCapture',
+	'onDoubleClick',
+	'onDoubleClickCapture',
+	'onDrag',
+	'onDragCapture',
+	'onDragEnd',
+	'onDragEndCapture',
+	'onDragEnter',
+	'onDragEnterCapture',
+	'onDragExit',
+	'onDragExitCapture',
+	'onDragLeave',
+	'onDragLeaveCapture',
+	'onDragOver',
+	'onDragOverCapture',
+	'onDragStart',
+	'onDragStartCapture',
+	'onDrop',
+	'onDropCapture',
+	'onMouseDown',
+	'onMouseDownCapture',
+	'onMouseEnter',
+	'onMouseLeave',
+	'onMouseMove',
+	'onMouseMoveCapture',
+	'onMouseOut',
+	'onMouseOutCapture',
+	'onMouseOver',
+	'onMouseOverCapture',
+	'onMouseUp',
+	'onMouseUpCapture',
+	'onSelect',
+	'onSelectCapture',
+	'onTouchCancel',
+	'onTouchCancelCapture',
+	'onTouchEnd',
+	'onTouchEndCapture',
+	'onTouchMove',
+	'onTouchMoveCapture',
+	'onTouchStart',
+	'onTouchStartCapture',
+	'onPointerDown',
+	'onPointerDownCapture',
+	'onPointerMove',
+	'onPointerMoveCapture',
+	'onPointerUp',
+	'onPointerUpCapture',
+	'onPointerCancel',
+	'onPointerCancelCapture',
+	'onPointerEnter',
+	'onPointerEnterCapture',
+	'onPointerLeave',
+	'onPointerLeaveCapture',
+	'onPointerOver',
+	'onPointerOverCapture',
+	'onPointerOut',
+	'onPointerOutCapture',
+	'onGotPointerCapture',
+	'onGotPointerCaptureCapture',
+	'onLostPointerCapture',
+	'onLostPointerCaptureCapture',
+	'onScroll',
+	'onScrollCapture',
+	'onWheel',
+	'onWheelCapture',
+	'onAnimationStart',
+	'onAnimationStartCapture',
+	'onAnimationEnd',
+	'onAnimationEndCapture',
+	'onAnimationIteration',
+	'onAnimationIterationCapture',
+	'onTransitionEnd',
+	'onTransitionEndCapture',
+];
+
+const useClientRegex = /^('|")use client('|")/;
+const browserOnlyGlobals = Object.keys(globals.browser).reduce((acc, curr) => {
+	if (curr in globals.browser && !(curr in globals.node)) {
+		acc.add(curr);
+	}
+	return acc;
+}, /* @__PURE__ */ new Set());
+
+// Create the ClientComponents rule using the object-style (required in v9)
+const ClientComponents = {
+	meta: {
+		docs: {
+			description:
+				"Enforce components are appropriately labeled with 'use client'.",
+			recommended: true,
+		},
+		type: 'problem',
+		hasSuggestions: true,
+		fixable: 'code',
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					allowedServerHooks: { type: 'array', items: { type: 'string' } },
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			addUseClientHooks:
+				'{{hook}} only works in Client Components. Add the "use client" directive at the top of the file to use it.',
+			addUseClientBrowserAPI:
+				'Browser APIs only work in Client Components. Add the "use client" directive at the top of the file to use it.',
+			addUseClientCallbacks:
+				'Functions can only be passed as props to Client Components. Add the "use client" directive at the top of the file to use it.',
+			addUseClientClassComponent:
+				'React Class Components can only be used in Client Components. Add the "use client" directive at the top of the file.',
+			removeUseClient:
+				"This file does not require the 'use client' directive, and it should be removed.",
+		},
+	},
+	create: Components.detect((context, _, util) => {
+		let hasReported = false;
+		const instances = [];
+		let isClientComponent = false;
+		const sourceCode = context.sourceCode;
+		const options = context.options?.[0] || {};
+		let parentNode;
+		function isClientOnlyHook(name) {
+			return (
+				// `useId` is the only hook that's allowed in server components
+				name !== 'useId' &&
+				!(options.allowedServerHooks || []).includes(name) &&
+				/^use[A-Z]/.test(name)
+			);
+		}
+		function reportMissingDirective(messageId, expression, data) {
+			if (isClientComponent || hasReported) {
+				return;
+			}
+			hasReported = true;
+			context.report({
+				node: expression,
+				messageId,
+				data,
+				*fix(fixer) {
+					const firstToken = sourceCode.getFirstToken(parentNode.body[0]);
+					if (firstToken) {
+						const isFirstLine = firstToken.loc.start.line === 1;
+						yield fixer.insertTextBefore(
+							firstToken,
+							`${isFirstLine ? '' : '\n'}'use client';
+
+`,
+						);
+					}
+				},
+			});
+		}
+		const reactImports = {
+			namespace: [],
+		};
+		const undeclaredReferences = /* @__PURE__ */ new Set();
+		return {
+			Program(node) {
+				for (const block of node.body) {
+					if (
+						block.type === 'ExpressionStatement' &&
+						block.expression.type === 'Literal' &&
+						block.expression.value === 'use client'
+					) {
+						isClientComponent = true;
+					}
+				}
+				parentNode = node;
+				const scope = sourceCode.getScope(node);
+
+				for (const reference of scope.through) {
+					undeclaredReferences.add(reference.identifier.name);
+				}
+			},
+			ImportDeclaration(node) {
+				if (node.source.value === 'react') {
+					const importSpecifiers = node.specifiers.filter(
+						(spec) => spec.type === 'ImportSpecifier',
+					);
+
+					for (const spec of importSpecifiers) {
+						reactImports[spec.local.name] = spec.imported.name;
+					}
+
+					const namespace = node.specifiers.find(
+						(spec) =>
+							spec.type === 'ImportDefaultSpecifier' ||
+							spec.type === 'ImportNamespaceSpecifier',
+					);
+					if (namespace) {
+						reactImports.namespace = [
+							...reactImports.namespace,
+							namespace.local.name,
+						];
+					}
+				}
+			},
+			NewExpression(node) {
+				const name = node.callee.name;
+				if (undeclaredReferences.has(name) && browserOnlyGlobals.has(name)) {
+					instances.push(name);
+					reportMissingDirective('addUseClientBrowserAPI', node);
+				}
+			},
+			CallExpression(expression) {
+				let name = '';
+				if (
+					expression.callee.type === 'Identifier' &&
+					'name' in expression.callee
+				) {
+					name = expression.callee.name;
+				} else if (
+					expression.callee.type === 'MemberExpression' &&
+					'name' in expression.callee.property
+				) {
+					name = expression.callee.property.name;
+				}
+				if (
+					isClientOnlyHook(name) && // Is in a function...
+					sourceCode.getScope(expression).type === 'function' && // But only if that function is a component
+					Boolean(util.getParentComponent(expression))
+				) {
+					instances.push(name);
+					reportMissingDirective('addUseClientHooks', expression.callee, {
+						hook: name,
+					});
+				}
+			},
+			MemberExpression(node) {
+				const name = node.object.name;
+				const scopeType = sourceCode.getScope(node).type;
+				if (
+					undeclaredReferences.has(name) &&
+					browserOnlyGlobals.has(name) &&
+					(scopeType === 'module' || !!util.getParentComponent(node))
+				) {
+					instances.push(name);
+					reportMissingDirective('addUseClientBrowserAPI', node.object);
+				}
+			},
+			ExpressionStatement(node) {
+				const expression = node.expression;
+				if (!expression.callee) {
+					return;
+				}
+				if (
+					expression.callee &&
+					isClientOnlyHook(expression.callee.name) &&
+					Boolean(util.getParentComponent(expression))
+				) {
+					instances.push(expression.callee.name);
+					reportMissingDirective('addUseClientHooks', expression.callee, {
+						hook: expression.callee.name,
+					});
+				}
+			},
+			JSXOpeningElement(node) {
+				const scope = sourceCode.getScope(node);
+				const fnsInScope = [];
+
+				for (const variable of scope.variables) {
+					for (const def of variable.defs) {
+						if (isFunction(def)) {
+							fnsInScope.push(variable.name);
+						}
+					}
+				}
+
+				if (scope.upper?.set) {
+					for (const variable of scope.upper.set) {
+						for (const def of variable.defs) {
+							if (isFunction(def)) {
+								fnsInScope.push(variable.name);
+							}
+						}
+					}
+				}
+
+				for (const attribute of node.attributes) {
+					if (
+						attribute.type === 'JSXSpreadAttribute' ||
+						attribute.value?.type !== 'JSXExpressionContainer'
+					) {
+						continue;
+					}
+					if (reactEvents.includes(attribute.name.name)) {
+						reportMissingDirective('addUseClientCallbacks', attribute.name);
+					}
+					if (
+						attribute.value?.expression.type === 'ArrowFunctionExpression' ||
+						attribute.value?.expression.type === 'FunctionExpression' ||
+						(attribute.value.expression.type === 'Identifier' &&
+							fnsInScope.includes(attribute.value.expression.name))
+					) {
+						reportMissingDirective('addUseClientCallbacks', attribute);
+					}
+				}
+			},
+			ClassDeclaration(node) {
+				if (componentUtil.isES6Component(node, context)) {
+					instances.push(node.id?.name);
+					reportMissingDirective('addUseClientClassComponent', node);
+				}
+			},
+			'ExpressionStatement:exit'(node) {
+				const value = 'value' in node.expression ? node.expression.value : '';
+				if (typeof value !== 'string' || !useClientRegex.test(value)) {
+					return;
+				}
+				if (instances.length === 0 && isClientComponent) {
+					context.report({
+						node,
+						messageId: 'removeUseClient',
+						fix(fixer) {
+							return fixer.remove(node);
+						},
+					});
+				}
+			},
+		};
+	}),
+};
+
+function isFunction(def) {
+	if (def.type === 'FunctionName') {
+		return true;
+	}
+	if (def.node.init && def.node.init.type === 'ArrowFunctionExpression') {
+		return true;
+	}
+	return false;
+}
+
+const plugin = {
+	meta: {
+		name: 'react-server-components',
+	},
+	rules: {
+		'use-client': ClientComponents,
+	},
+	configs: {},
+};
+
+Object.assign(plugin.configs, {
+	recommended: {
+		plugins: {
+			'react-server-components': plugin,
+		},
+		rules: {
+			'react-server-components/use-client': 'error',
+		},
+	},
+});
+
+export default plugin;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -81,6 +81,7 @@
 		"@vanilla-extract/vite-plugin": "^5.0.1",
 		"@vitest/coverage-v8": "3.0.8",
 		"ctix": "catalog:",
+		"esbuild-plugin-preserve-directives": "^0.0.11",
 		"eslint": "^9",
 		"eslint-config-biome": "^1.9.4",
 		"eslint-plugin-react": "^7.37.4",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,8 +49,8 @@
 		"@radix-ui/react-popover": "catalog:",
 		"@radix-ui/react-select": "catalog:",
 		"date-fns": "catalog:",
-		"react-day-picker": "catalog:",
 		"dnum": "catalog:",
+		"react-day-picker": "catalog:",
 		"zod": "^3.24.2"
 	},
 	"peerDependencies": {
@@ -70,6 +70,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
+		"@eslint/js": "^9.22.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
 		"@types/react": "catalog:",
@@ -78,7 +79,13 @@
 		"@vanilla-extract/esbuild-plugin": "catalog:",
 		"@vanilla-extract/recipes": "catalog:",
 		"@vanilla-extract/vite-plugin": "^5.0.1",
+		"@vitest/coverage-v8": "3.0.8",
 		"ctix": "catalog:",
+		"eslint": "^9",
+		"eslint-config-biome": "^1.9.4",
+		"eslint-plugin-react": "^7.37.4",
+		"eslint-plugin-react-hooks": "^5.2.0",
+		"globals": "^16.0.0",
 		"happy-dom": "^17.1.1",
 		"jsdom": "^26.0.0",
 		"msw": "^2.7.1",
@@ -86,8 +93,8 @@
 		"rimraf": "catalog:",
 		"tsup": "catalog:",
 		"typescript": "catalog:",
+		"typescript-eslint": "^8.26.1",
 		"vite-tsconfig-paths": "catalog:",
-		"vitest": "^3.0.8",
-		"@vitest/coverage-v8": "3.0.8"
+		"vitest": "^3.0.8"
 	}
 }

--- a/packages/sdk/src/react/__tests__/provider.test.tsx
+++ b/packages/sdk/src/react/__tests__/provider.test.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { render, screen } from '@testing-library/react';
 import { useContext } from 'react';

--- a/packages/sdk/src/react/hooks/useCancelOrder.tsx
+++ b/packages/sdk/src/react/hooks/useCancelOrder.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useWaasFeeOptions } from '@0xsequence/kit';
 import { useEffect, useState } from 'react';
 import type { MarketplaceKind } from '../../types';

--- a/packages/sdk/src/react/ui/components/_internals/action-button/__tests__/ActionButtonBody.test.tsx
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/__tests__/ActionButtonBody.test.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as kit from '@0xsequence/kit';
 import { fireEvent, render, screen } from '@test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/sdk/src/react/ui/components/_internals/action-button/components/ActionButtonBody.tsx
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/components/ActionButtonBody.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Button } from '@0xsequence/design-system';
 import { useOpenConnectModal } from '@0xsequence/kit';
 import { useAccount } from 'wagmi';

--- a/packages/sdk/src/react/ui/components/_internals/action-button/components/NonOwnerActions.tsx
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/components/NonOwnerActions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Hex } from 'viem';
 import { InvalidStepError } from '../../../../../../utils/_internal/error/transaction';
 import type { Order, OrderbookKind } from '../../../../../_internal';

--- a/packages/sdk/src/react/ui/components/_internals/action-button/components/OwnerActions.tsx
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/components/OwnerActions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Hex } from 'viem';
 import type { Order, OrderbookKind } from '../../../../../_internal';
 import { useCreateListingModal } from '../../../../modals/CreateListingModal';

--- a/packages/sdk/src/react/ui/components/_internals/action-button/hooks/useActionButtonLogic.ts
+++ b/packages/sdk/src/react/ui/components/_internals/action-button/hooks/useActionButtonLogic.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 import { useAccount } from 'wagmi';
 import {

--- a/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/CollectibleCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 import { Box, IconButton, Skeleton } from '@0xsequence/design-system';

--- a/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
 	Box,
 	ChevronLeftIcon,

--- a/packages/sdk/src/react/ui/icons/BellIcon.tsx
+++ b/packages/sdk/src/react/ui/icons/BellIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, type IconProps } from '@0xsequence/design-system';
 import { iconVariants } from './styles.css';
 

--- a/packages/sdk/src/react/ui/icons/CalendarIcon.tsx
+++ b/packages/sdk/src/react/ui/icons/CalendarIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, type IconProps } from '@0xsequence/design-system';
 import { iconVariants } from './styles.css';
 

--- a/packages/sdk/src/react/ui/icons/CartIcon.tsx
+++ b/packages/sdk/src/react/ui/icons/CartIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, type IconProps } from '@0xsequence/design-system';
 import { iconVariants } from './styles.css';
 

--- a/packages/sdk/src/react/ui/icons/InfoIcon.tsx
+++ b/packages/sdk/src/react/ui/icons/InfoIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, type IconProps } from '@0xsequence/design-system';
 import { iconVariants } from './styles.css';
 

--- a/packages/sdk/src/react/ui/images/marketplaces/LooksRare.tsx
+++ b/packages/sdk/src/react/ui/images/marketplaces/LooksRare.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, type IconProps } from '@0xsequence/design-system';
 import { iconVariants } from '../../icons/styles.css';
 

--- a/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { use$ } from '@legendapp/state/react';
 import type { Hex } from 'viem';
 import { ContractType, type TokenMetadata } from '../../../_internal';

--- a/packages/sdk/src/react/ui/modals/BuyModal/modals/CheckoutModal.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/modals/CheckoutModal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 import { parseUnits } from 'viem';
 import type { Order } from '../../../../_internal';

--- a/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
+++ b/packages/sdk/src/react/ui/modals/BuyModal/modals/Modal1155.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box } from '@0xsequence/design-system';
 import { observer } from '@legendapp/state/react';
 import type { Hex } from 'viem';

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box } from '@0xsequence/design-system';
 import { Show, observer } from '@legendapp/state/react';
 import { parseUnits } from 'viem';

--- a/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useCreateListing.tsx
+++ b/packages/sdk/src/react/ui/modals/CreateListingModal/hooks/useCreateListing.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Observable } from '@legendapp/state';
 import { useEffect } from 'react';
 import {

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Show, observer } from '@legendapp/state/react';
 import { useState } from 'react';
 import { parseUnits } from 'viem';

--- a/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useMakeOffer.tsx
+++ b/packages/sdk/src/react/ui/modals/MakeOfferModal/hooks/useMakeOffer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Observable } from '@legendapp/state';
 import { useEffect } from 'react';
 import { OrderbookKind } from '../../../../../types';

--- a/packages/sdk/src/react/ui/modals/SellModal/hooks/useSell.tsx
+++ b/packages/sdk/src/react/ui/modals/SellModal/hooks/useSell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Observable } from '@legendapp/state';
 import { useEffect } from 'react';
 import type { MarketplaceKind, TransactionSteps } from '../../../../_internal';

--- a/packages/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/index.tsx
+++ b/packages/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Button, Text, TextInput } from '@0xsequence/design-system';
 import { observable } from '@legendapp/state';
 import { isAddress } from 'viem';

--- a/packages/sdk/src/react/ui/modals/TransferModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/TransferModal/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { CloseIcon, IconButton } from '@0xsequence/design-system';
 import { Show, observer } from '@legendapp/state/react';
 import { Close, Content, Overlay, Portal, Root } from '@radix-ui/react-dialog';

--- a/packages/sdk/src/react/ui/modals/_internal/components/currencyImage/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/currencyImage/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, TokenImage } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { useState } from 'react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/currencyOptionsSelect/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/currencyOptionsSelect/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Skeleton } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { observer } from '@legendapp/state/react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/expirationDateSelect/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/expirationDateSelect/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Skeleton, Text } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { observer } from '@legendapp/state/react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/floorPriceText/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/floorPriceText/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Text } from '@0xsequence/design-system';
 import type { Hex } from 'viem';
 import type { Price } from '../../../../../../types';

--- a/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, NumericInput, Text } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/quantityInput/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/quantityInput/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
 	AddIcon,
 	Box,

--- a/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/switchChainModal/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
 	Button,
 	CloseIcon,

--- a/packages/sdk/src/react/ui/modals/_internal/components/timeAgo/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/timeAgo/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Text } from '@0xsequence/design-system';
 import { formatDistanceToNow } from 'date-fns';
 import { useEffect, useState } from 'react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/tokenPreview/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/tokenPreview/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Image, Skeleton, Text } from '@0xsequence/design-system';
 import type { Hex } from 'viem';
 import { useCollectible } from '../../../../../hooks';

--- a/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/transactionDetails/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Image, Skeleton, Text } from '@0xsequence/design-system';
 import { type Hex, formatUnits } from 'viem';
 import { DEFAULT_MARKETPLACE_FEE_PERCENTAGE } from '../../../../../../consts';

--- a/packages/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/hooks/useTransactionStatus.ts
+++ b/packages/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/hooks/useTransactionStatus.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TransactionStatus as IndexerTransactionStatus } from '@0xsequence/indexer';
 import { skipToken, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';

--- a/packages/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
 	CloseIcon,
 	IconButton,

--- a/packages/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsBox/index.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsBox/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
 	Box,
 	Button,

--- a/packages/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsSelect/WaasFeeOptionsSelect.tsx
+++ b/packages/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsSelect/WaasFeeOptionsSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Box, Image, Text } from '@0xsequence/design-system';
 import type { Observable } from '@legendapp/state';
 import { observer } from '@legendapp/state/react';

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -6,5 +6,5 @@
 			"@test": ["./test/test-utils.tsx"]
 		}
 	},
-	"include": ["src", "tsup.config.ts", "test"]
+	"include": ["src", "tsup.config.ts", "test", "eslint.config.mjs", "eslint"]
 }

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,38 +1,23 @@
 import { vanillaExtractPlugin } from '@vanilla-extract/esbuild-plugin';
+import { preserveDirectivesPlugin } from 'esbuild-plugin-preserve-directives';
 import { defineConfig } from 'tsup';
 
 export default defineConfig([
 	{
-		entry: ['src/**/index.ts', '!src/react/**'],
+		entry: ['src/**/index.ts'],
 		dts: true,
 		sourcemap: true,
 		format: ['esm'],
-	},
-	{
-		entry: ['src/**/index.ts', '!src/react/ssr/index.ts'],
-		dts: true,
-		sourcemap: true,
-		format: ['esm'],
-		esbuildPlugins: [vanillaExtractPlugin()],
-		esbuildOptions(options) {
-			options.banner = {
-				js: '"use client"',
-			};
-		},
+		esbuildPlugins: [
+			vanillaExtractPlugin(),
+			preserveDirectivesPlugin({
+				directives: ['use client', 'use strict'],
+				include: /\.(js|ts|jsx|tsx)$/,
+				exclude: /node_modules/,
+			}),
+		],
 		loader: {
 			'.png': 'dataurl',
 		},
-	},
-	{
-		entry: { 'react/ssr/index': 'src/react/ssr/index.ts' },
-		dts: true,
-		sourcemap: true,
-		format: ['esm'],
-	},
-	{
-		entry: ['src/styles/index.ts'],
-		outDir: 'dist',
-		format: ['esm'],
-		esbuildPlugins: [vanillaExtractPlugin()],
 	},
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
+      '@eslint/js':
+        specifier: ^9.22.0
+        version: 9.22.0
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -234,6 +237,21 @@ importers:
       ctix:
         specifier: 'catalog:'
         version: 2.7.0(prettier-plugin-organize-imports@4.1.0(prettier@3.4.2)(typescript@5.8.2))(prettier@3.4.2)(typescript@5.8.2)
+      eslint:
+        specifier: ^9
+        version: 9.22.0(jiti@2.4.2)
+      eslint-config-biome:
+        specifier: ^1.9.4
+        version: 1.9.4
+      eslint-plugin-react:
+        specifier: ^7.37.4
+        version: 7.37.4(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.22.0(jiti@2.4.2))
+      globals:
+        specifier: ^16.0.0
+        version: 16.0.0
       happy-dom:
         specifier: ^17.1.1
         version: 17.1.1
@@ -255,6 +273,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
+      typescript-eslint:
+        specifier: ^8.26.1
+        version: 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 5.1.4(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(yaml@2.7.0))
@@ -2959,8 +2980,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/eslint-plugin@8.26.1':
+    resolution: {integrity: sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/parser@8.26.0':
     resolution: {integrity: sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.26.1':
+    resolution: {integrity: sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2970,8 +3006,19 @@ packages:
     resolution: {integrity: sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.26.1':
+    resolution: {integrity: sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@8.26.0':
     resolution: {integrity: sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.26.1':
+    resolution: {integrity: sha512-Kcj/TagJLwoY/5w9JGEFV0dclQdyqw9+VMndxOJKtoFSjfZhLXhYjzsQEeyza03rwHx2vFEGvrJWJBXKleRvZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2981,8 +3028,18 @@ packages:
     resolution: {integrity: sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.26.1':
+    resolution: {integrity: sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.26.0':
     resolution: {integrity: sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/typescript-estree@8.26.1':
+    resolution: {integrity: sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -2994,8 +3051,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@8.26.1':
+    resolution: {integrity: sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/visitor-keys@8.26.0':
     resolution: {integrity: sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.26.1':
+    resolution: {integrity: sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.0':
@@ -3995,6 +4063,9 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-biome@1.9.4:
+    resolution: {integrity: sha512-4HX+rfUk1R2rPwN3hcxPxq5sLDLGb/xtu48AggTtxCVoRoD18kjwOwHA1c7gYsbRrEQso+9mlRSS9+G7OfDqFg==}
+
   eslint-config-next@15.2.1:
     resolution: {integrity: sha512-mhsprz7l0no8X+PdDnVHF4dZKu9YBJp2Rf6ztWbXBLJ4h6gxmW//owbbGJMBVUU+PibGJDAqZhW4pt8SC8HSow==}
     peerDependencies:
@@ -4417,6 +4488,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.0.0:
+    resolution: {integrity: sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -6416,6 +6491,13 @@ packages:
   typed-function@4.2.1:
     resolution: {integrity: sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==}
     engines: {node: '>= 18'}
+
+  typescript-eslint@8.26.1:
+    resolution: {integrity: sha512-t/oIs9mYyrwZGRpDv3g+3K6nZ5uhKEMt2oNmAPwaY4/ye0+EH4nXIPYNtkYFS6QHm+1DFg34DbglYBz5P9Xysg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -10000,6 +10082,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/type-utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/visitor-keys': 8.26.1
+      eslint: 9.22.0(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.26.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.26.0
@@ -10012,10 +10111,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
+      '@typescript-eslint/visitor-keys': 8.26.1
+      debug: 4.4.0
+      eslint: 9.22.0(jiti@2.4.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.26.0':
     dependencies:
       '@typescript-eslint/types': 8.26.0
       '@typescript-eslint/visitor-keys': 8.26.0
+
+  '@typescript-eslint/scope-manager@8.26.1':
+    dependencies:
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/visitor-keys': 8.26.1
 
   '@typescript-eslint/type-utils@8.26.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
@@ -10028,12 +10144,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      debug: 4.4.0
+      eslint: 9.22.0(jiti@2.4.2)
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.26.0': {}
+
+  '@typescript-eslint/types@8.26.1': {}
 
   '@typescript-eslint/typescript-estree@8.26.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.26.0
       '@typescript-eslint/visitor-keys': 8.26.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.26.1(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/visitor-keys': 8.26.1
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -10055,9 +10198,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.22.0(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/types': 8.26.1
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
+      eslint: 9.22.0(jiti@2.4.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.26.0':
     dependencies:
       '@typescript-eslint/types': 8.26.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.26.1':
+    dependencies:
+      '@typescript-eslint/types': 8.26.1
       eslint-visitor-keys: 4.2.0
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.0':
@@ -11624,6 +11783,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-biome@1.9.4: {}
+
   eslint-config-next@15.2.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2):
     dependencies:
       '@next/eslint-plugin-next': 15.2.1
@@ -12153,6 +12314,8 @@ snapshots:
   globals@11.12.0: {}
 
   globals@14.0.0: {}
+
+  globals@16.0.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -14217,6 +14380,16 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typed-function@4.2.1: {}
+
+  typescript-eslint@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.22.0(jiti@2.4.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.8.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,9 @@ settings:
 
 catalogs:
   default:
-    0xsequence:
-      specifier: ^2.2.14
-      version: 2.2.14
     '@0xsequence/api':
       specifier: ^2.2.14
       version: 2.2.14
-    '@0xsequence/design-system':
-      specifier: ^1.9.0
-      version: 1.9.0
     '@0xsequence/indexer':
       specifier: ^2.2.14
       version: 2.2.14
@@ -237,6 +231,9 @@ importers:
       ctix:
         specifier: 'catalog:'
         version: 2.7.0(prettier-plugin-organize-imports@4.1.0(prettier@3.4.2)(typescript@5.8.2))(prettier@3.4.2)(typescript@5.8.2)
+      esbuild-plugin-preserve-directives:
+        specifier: ^0.0.11
+        version: 0.0.11(esbuild@0.25.0)
       eslint:
         specifier: ^9
         version: 9.22.0(jiti@2.4.2)
@@ -290,7 +287,7 @@ importers:
         version: 2.2.14
       '@0xsequence/design-system':
         specifier: ^1.9.0
-        version: 1.9.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(framer-motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.9.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(framer-motion@8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@0xsequence/design-system2':
         specifier: npm:@0xsequence/design-system@2
         version: '@0xsequence/design-system@2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
@@ -302,10 +299,10 @@ importers:
         version: 4.6.5(0xsequence@2.2.14(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@databeat/tracker@0.9.3)(@react-oauth/google@0.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/react-query@5.67.2(react@18.3.1))(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(react-apple-signin-auth@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))(wagmi@2.14.13(@tanstack/query-core@5.67.2)(@tanstack/react-query@5.67.2(react@18.3.1))(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2))
       '@0xsequence/kit-checkout':
         specifier: 'catalog:'
-        version: 4.6.5(wro7de57ilourhwk362pgi3ykq)
+        version: 4.6.5(ds4af735f5viw5elhejn5fqoda)
       '@0xsequence/kit-wallet':
         specifier: ^4.6.4
-        version: 4.6.5(7yrl3iahneltk5sv47n76msitm)
+        version: 4.6.5(ftm45pra5lkab3cnuvhhti2frm)
       '@0xsequence/marketplace-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -4038,6 +4035,12 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild-plugin-preserve-directives@0.0.11:
+    resolution: {integrity: sha512-OolFhx1h/1ADEEoPjVi0hYWru1pTZBHki7XozawYVkhRhO63mwZT6isLylbwPs7dJ72doVQJGHCT2I1l9z8DcA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      esbuild: ^0.21.0
+
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
@@ -7267,10 +7270,10 @@ snapshots:
       viem: 2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
       wagmi: 2.14.13(@tanstack/query-core@5.67.2)(@tanstack/react-query@5.67.2(react@18.3.1))(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)
 
-  '@0xsequence/kit-wallet@4.6.5(7yrl3iahneltk5sv47n76msitm)':
+  '@0xsequence/kit-wallet@4.6.5(ftm45pra5lkab3cnuvhhti2frm)':
     dependencies:
       '@0xsequence/api': 2.2.14
-      '@0xsequence/design-system': 1.9.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(framer-motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@0xsequence/design-system': 1.9.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(framer-motion@8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@0xsequence/indexer': 2.2.14
       '@0xsequence/kit': 4.6.5(0xsequence@2.2.14(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@databeat/tracker@0.9.3)(@react-oauth/google@0.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/react-query@5.67.2(react@18.3.1))(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(react-apple-signin-auth@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))(wagmi@2.14.13(@tanstack/query-core@5.67.2)(@tanstack/react-query@5.67.2(react@18.3.1))(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.23.9(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2))
       '@0xsequence/metadata': 2.2.14
@@ -7279,7 +7282,7 @@ snapshots:
       '@tanstack/react-query': 5.67.2(react@18.3.1)
       dayjs: 1.11.13
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      framer-motion: 12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      framer-motion: 8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fuse.js: 6.6.2
       qrcode.react: 4.2.0(react@18.3.1)
       react: 18.3.1
@@ -11718,6 +11721,10 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild-plugin-preserve-directives@0.0.11(esbuild@0.25.0):
+    dependencies:
+      esbuild: 0.25.0
 
   esbuild@0.24.2:
     optionalDependencies:


### PR DESCRIPTION
- Uses a esbuild plugin to preserve "use client" directives
- Includes a custom eslint plugin to ensure the client directive is there when needed based on https://github.com/roginfarrer/eslint-plugin-react-server-components