### PR TITLE
Prevent default and stop propagation on offer click in Footer component

### DIFF
--- a/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
+++ b/packages/sdk/src/react/ui/components/collectible-card/Footer.tsx
@@ -124,7 +124,9 @@ export const Footer = ({
 						right="0"
 						top="0"
 						onClick={(e) => {
+							e.preventDefault();
 							e.stopPropagation();
+
 							onOfferClick?.();
 						}}
 						icon={(props) => <SvgBellIcon {...props} size={'xs'} />}


### PR DESCRIPTION
In case the `CollectibleCard` is wrapped with an anchor tag, listening onClick event of offer bell button is broken. This PR is for fixing this behavior.