### PR TITLE
Fix React state update during render in BuyModal component

### DIFF
--- a/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -30,7 +30,7 @@ export const BuyModal = () => {
 };
 
 const BuyModalContent = () => {
-	const { chainId, skipNativeBalanceCheck } = useBuyModalProps();
+	const { chainId } = useBuyModalProps();
 
 	const onError = useOnError();
 
@@ -100,34 +100,25 @@ const BuyModalContent = () => {
 	}
 
 	if (paymentModalParams) {
-		return (
-			<PaymentModalOpener
-				paymentModalParams={paymentModalParams}
-				skipNativeBalanceCheck={skipNativeBalanceCheck ?? false}
-			/>
-		);
+		return <PaymentModalOpener paymentModalParams={paymentModalParams} />;
 	}
 };
 
 const PaymentModalOpener = ({
 	paymentModalParams,
-	skipNativeBalanceCheck,
 }: {
 	paymentModalParams: SelectPaymentSettings;
-	skipNativeBalanceCheck: boolean;
 }) => {
 	const { openSelectPaymentModal } = useSelectPaymentModal();
 	const hasOpenedRef = useRef(false);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	useEffect(() => {
 		if (!hasOpenedRef.current) {
 			hasOpenedRef.current = true;
-			openSelectPaymentModal({
-				...paymentModalParams,
-				skipNativeBalanceCheck,
-			});
+			openSelectPaymentModal(paymentModalParams);
 		}
-	});
+	}, []);
 
 	return null;
 };

--- a/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -120,14 +120,14 @@ const PaymentModalOpener = ({
 	const hasOpenedRef = useRef(false);
 
 	useEffect(() => {
-		if (paymentModalParams && !hasOpenedRef.current) {
+		if (!hasOpenedRef.current) {
 			hasOpenedRef.current = true;
 			openSelectPaymentModal({
 				...paymentModalParams,
 				skipNativeBalanceCheck,
 			});
 		}
-	}, [paymentModalParams, skipNativeBalanceCheck, openSelectPaymentModal]);
+	});
 
 	return null;
 };

--- a/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -64,6 +64,16 @@ const BuyModalContent = () => {
 		}
 	}, [collection]);
 
+	// Effect to handle opening the payment modal
+	useEffect(() => {
+		if (paymentModalParams) {
+			openSelectPaymentModal({
+				...paymentModalParams,
+				skipNativeBalanceCheck,
+			});
+		}
+	}, [paymentModalParams, skipNativeBalanceCheck, openSelectPaymentModal]);
+
 	if (isError || isPaymentModalParamsError) {
 		onError(new Error('Error loading data'));
 		return (
@@ -95,12 +105,5 @@ const BuyModalContent = () => {
 
 	if (collection.type === ContractType.ERC1155 && !quantity) {
 		return <ERC1155QuantityModal order={order} />;
-	}
-
-	if (paymentModalParams) {
-		openSelectPaymentModal({
-			...paymentModalParams,
-			skipNativeBalanceCheck,
-		});
 	}
 };

--- a/sdk/src/react/ui/modals/BuyModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/Modal.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useSelectPaymentModal } from '@0xsequence/checkout';
-import { useEffect } from 'react';
+import {
+	type SelectPaymentSettings,
+	useSelectPaymentModal,
+} from '@0xsequence/checkout';
+import { useEffect, useRef } from 'react';
 import { ContractType } from '../../../_internal';
 import { ErrorModal } from '../_internal/components/actionModal/ErrorModal';
 import { LoadingModal } from '../_internal/components/actionModal/LoadingModal';
@@ -31,7 +34,6 @@ const BuyModalContent = () => {
 
 	const onError = useOnError();
 
-	const { openSelectPaymentModal } = useSelectPaymentModal();
 	const quantity = useQuantity();
 
 	const {
@@ -63,16 +65,6 @@ const BuyModalContent = () => {
 			buyModalStore.send({ type: 'setQuantity', quantity: 1 });
 		}
 	}, [collection]);
-
-	// Effect to handle opening the payment modal
-	useEffect(() => {
-		if (paymentModalParams) {
-			openSelectPaymentModal({
-				...paymentModalParams,
-				skipNativeBalanceCheck,
-			});
-		}
-	}, [paymentModalParams, skipNativeBalanceCheck, openSelectPaymentModal]);
 
 	if (isError || isPaymentModalParamsError) {
 		onError(new Error('Error loading data'));
@@ -106,4 +98,36 @@ const BuyModalContent = () => {
 	if (collection.type === ContractType.ERC1155 && !quantity) {
 		return <ERC1155QuantityModal order={order} />;
 	}
+
+	if (paymentModalParams) {
+		return (
+			<PaymentModalOpener
+				paymentModalParams={paymentModalParams}
+				skipNativeBalanceCheck={skipNativeBalanceCheck ?? false}
+			/>
+		);
+	}
+};
+
+const PaymentModalOpener = ({
+	paymentModalParams,
+	skipNativeBalanceCheck,
+}: {
+	paymentModalParams: SelectPaymentSettings;
+	skipNativeBalanceCheck: boolean;
+}) => {
+	const { openSelectPaymentModal } = useSelectPaymentModal();
+	const hasOpenedRef = useRef(false);
+
+	useEffect(() => {
+		if (paymentModalParams && !hasOpenedRef.current) {
+			hasOpenedRef.current = true;
+			openSelectPaymentModal({
+				...paymentModalParams,
+				skipNativeBalanceCheck,
+			});
+		}
+	}, [paymentModalParams, skipNativeBalanceCheck, openSelectPaymentModal]);
+
+	return null;
 };

--- a/sdk/src/react/ui/modals/BuyModal/hooks/usePaymentModalParams.ts
+++ b/sdk/src/react/ui/modals/BuyModal/hooks/usePaymentModalParams.ts
@@ -57,6 +57,7 @@ export const getBuyCollectableParams = async ({
 	collectable,
 	checkoutOptions,
 	fee,
+	skipNativeBalanceCheck,
 }: GetBuyCollectableParams) => {
 	const marketplaceClient = getMarketplaceClient(chainId, config);
 	const { steps } = await marketplaceClient.generateBuyTransaction({
@@ -119,6 +120,7 @@ export const getBuyCollectableParams = async ({
 			queryClient.invalidateQueries();
 			buyModalStore.send({ type: 'close' });
 		},
+		skipNativeBalanceCheck,
 		...(customCreditCardProviderCallback && {
 			customProviderCallback: () => {
 				customCreditCardProviderCallback(buyStep);
@@ -147,6 +149,7 @@ export const usePaymentModalParams = (args: usePaymentModalParams) => {
 		quantity,
 	} = args;
 
+	const buyModalProps = useBuyModalProps();
 	const {
 		chainId,
 		collectionAddress,
@@ -154,7 +157,8 @@ export const usePaymentModalParams = (args: usePaymentModalParams) => {
 		orderId,
 		customCreditCardProviderCallback,
 		skipNativeBalanceCheck,
-	} = useBuyModalProps();
+	} = buyModalProps;
+
 	const config = useConfig();
 	const fee = useFees({
 		chainId,
@@ -172,7 +176,7 @@ export const usePaymentModalParams = (args: usePaymentModalParams) => {
 		!!quantity;
 
 	return useQuery({
-		queryKey: ['buyCollectableParams', args, quantity, fee],
+		queryKey: ['buyCollectableParams', buyModalProps, args, fee],
 		queryFn: enabled
 			? () =>
 					getBuyCollectableParams({


### PR DESCRIPTION
Moved the`openSelectPaymentModal` call into a `useEffect` hook to ensure state updates happen after render completion rather than during the render phase. This follows React's best practices for handling side effects and state updates.