### PR TITLE
Tests of `OfferModal`

### DIFF
--- a/sdk/src/react/_internal/api/__mocks__/marketplace.msw.ts
+++ b/sdk/src/react/_internal/api/__mocks__/marketplace.msw.ts
@@ -141,20 +141,17 @@ export const mockCollection: Collection = {
 	updatedAt: new Date().toISOString(),
 };
 
-export const mockSteps: Step[] = [
-	{
-		id: StepType.tokenApproval,
-		data: '0x...',
-		to: '0x1234567890123456789012345678901234567890',
-		value: '0',
-		price: '0',
-		post: {
-			method: 'POST',
-			endpoint: '/api/order',
-			body: {},
-		},
-	},
-];
+// Create a function that returns a Step object
+export const createMockStep = (step: StepType): Step => ({
+	id: step,
+	data: '0x...',
+	to: '0x1234567890123456789012345678901234567890',
+	value: '0',
+	price: '0',
+});
+
+export const createMockSteps = (steps: StepType[]): Step[] =>
+	steps.map(createMockStep);
 
 export const mockCheckoutOptions: CheckoutOptionsMarketplaceReturn = {
 	options: {
@@ -310,24 +307,25 @@ export const handlers = [
 		page: { page: 1, pageSize: 10, more: false },
 	}),
 
+	// by default, all endpoints include a tokenApproval step
 	mockMarketplaceHandler('GenerateBuyTransaction', {
-		steps: mockSteps,
+		steps: createMockSteps([StepType.buy]),
 	}),
 
 	mockMarketplaceHandler('GenerateSellTransaction', {
-		steps: mockSteps,
+		steps: createMockSteps([StepType.tokenApproval, StepType.sell]),
 	}),
 
 	mockMarketplaceHandler('GenerateListingTransaction', {
-		steps: mockSteps,
+		steps: createMockSteps([StepType.tokenApproval, StepType.createListing]),
 	}),
 
 	mockMarketplaceHandler('GenerateOfferTransaction', {
-		steps: mockSteps,
+		steps: createMockSteps([StepType.tokenApproval, StepType.createOffer]),
 	}),
 
 	mockMarketplaceHandler('GenerateCancelTransaction', {
-		steps: mockSteps,
+		steps: createMockSteps([StepType.cancel]),
 	}),
 
 	mockMarketplaceHandler('Execute', {

--- a/sdk/src/react/hooks/__tests__/useCancelTransactionSteps.test.tsx
+++ b/sdk/src/react/hooks/__tests__/useCancelTransactionSteps.test.tsx
@@ -12,8 +12,9 @@ import {
 	WalletInstanceNotFoundError,
 } from '../../../utils/_internal/error/transaction';
 import {
+	createMockStep,
+	createMockSteps,
 	mockMarketplaceEndpoint,
-	mockSteps,
 } from '../../_internal/api/__mocks__/marketplace.msw';
 import { MarketplaceKind, StepType } from '../../_internal/api/marketplace.gen';
 import { useWallet } from '../../_internal/wallet/useWallet';
@@ -66,12 +67,7 @@ describe('useCancelTransactionSteps', () => {
 		server.use(
 			http.post(mockMarketplaceEndpoint('GenerateCancelTransaction'), () => {
 				return HttpResponse.json({
-					steps: [
-						{
-							...mockSteps[0],
-							id: StepType.cancel,
-						},
-					],
+					steps: createMockSteps([StepType.cancel]),
 				});
 			}),
 		);
@@ -106,8 +102,7 @@ describe('useCancelTransactionSteps', () => {
 				return HttpResponse.json({
 					steps: [
 						{
-							...mockSteps[0],
-							id: StepType.signEIP712,
+							...createMockStep(StepType.signEIP712),
 						},
 					],
 				});

--- a/sdk/src/react/hooks/__tests__/useGenerateCancelTransaction.test.tsx
+++ b/sdk/src/react/hooks/__tests__/useGenerateCancelTransaction.test.tsx
@@ -3,10 +3,11 @@ import { http, HttpResponse } from 'msw';
 import { zeroAddress } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
 import {
+	createMockStep,
+	createMockSteps,
 	mockMarketplaceEndpoint,
-	mockSteps,
 } from '../../_internal/api/__mocks__/marketplace.msw';
-import { MarketplaceKind } from '../../_internal/api/marketplace.gen';
+import { MarketplaceKind, StepType } from '../../_internal/api/marketplace.gen';
 import { useGenerateCancelTransaction } from '../useGenerateCancelTransaction';
 
 const defaultArgs = {
@@ -28,7 +29,7 @@ describe('useGenerateCancelTransaction', () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.data).toEqual(mockSteps);
+			expect(result.current.data).toEqual(createMockSteps([StepType.cancel]));
 		});
 		expect(result.current.error).toBeNull();
 	});
@@ -123,7 +124,7 @@ describe('useGenerateCancelTransaction', () => {
 
 		await waitFor(() => {
 			expect(onSuccess).toHaveBeenCalledWith(
-				[mockSteps[0]],
+				[createMockStep(StepType.cancel)],
 				defaultArgs,
 				undefined,
 			);

--- a/sdk/src/react/hooks/__tests__/useGenerateListingTransaction.test.tsx
+++ b/sdk/src/react/hooks/__tests__/useGenerateListingTransaction.test.tsx
@@ -51,11 +51,13 @@ describe('useGenerateListingTransaction', () => {
 			    {
 			      "data": "0x...",
 			      "id": "tokenApproval",
-			      "post": {
-			        "body": {},
-			        "endpoint": "/api/order",
-			        "method": "POST",
-			      },
+			      "price": "0",
+			      "to": "0x1234567890123456789012345678901234567890",
+			      "value": "0",
+			    },
+			    {
+			      "data": "0x...",
+			      "id": "createListing",
 			      "price": "0",
 			      "to": "0x1234567890123456789012345678901234567890",
 			      "value": "0",
@@ -96,11 +98,13 @@ describe('useGenerateListingTransaction', () => {
 			    {
 			      "data": "0x...",
 			      "id": "tokenApproval",
-			      "post": {
-			        "body": {},
-			        "endpoint": "/api/order",
-			        "method": "POST",
-			      },
+			      "price": "0",
+			      "to": "0x1234567890123456789012345678901234567890",
+			      "value": "0",
+			    },
+			    {
+			      "data": "0x...",
+			      "id": "createListing",
 			      "price": "0",
 			      "to": "0x1234567890123456789012345678901234567890",
 			      "value": "0",

--- a/sdk/src/react/hooks/__tests__/useGenerateOfferTransaction.test.tsx
+++ b/sdk/src/react/hooks/__tests__/useGenerateOfferTransaction.test.tsx
@@ -50,11 +50,13 @@ describe('useGenerateOfferTransaction', () => {
 			    {
 			      "data": "0x...",
 			      "id": "tokenApproval",
-			      "post": {
-			        "body": {},
-			        "endpoint": "/api/order",
-			        "method": "POST",
-			      },
+			      "price": "0",
+			      "to": "0x1234567890123456789012345678901234567890",
+			      "value": "0",
+			    },
+			    {
+			      "data": "0x...",
+			      "id": "createOffer",
 			      "price": "0",
 			      "to": "0x1234567890123456789012345678901234567890",
 			      "value": "0",
@@ -94,11 +96,13 @@ describe('useGenerateOfferTransaction', () => {
 			    {
 			      "data": "0x...",
 			      "id": "tokenApproval",
-			      "post": {
-			        "body": {},
-			        "endpoint": "/api/order",
-			        "method": "POST",
-			      },
+			      "price": "0",
+			      "to": "0x1234567890123456789012345678901234567890",
+			      "value": "0",
+			    },
+			    {
+			      "data": "0x...",
+			      "id": "createOffer",
 			      "price": "0",
 			      "to": "0x1234567890123456789012345678901234567890",
 			      "value": "0",

--- a/sdk/src/react/hooks/__tests__/useGenerateSellTransaction.test.tsx
+++ b/sdk/src/react/hooks/__tests__/useGenerateSellTransaction.test.tsx
@@ -3,13 +3,14 @@ import { http, HttpResponse } from 'msw';
 import { zeroAddress } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	createMockSteps,
 	mockMarketplaceEndpoint,
-	mockSteps,
 } from '../../_internal/api/__mocks__/marketplace.msw';
 import {
 	ContractType,
 	MarketplaceKind,
 	OrderbookKind,
+	StepType,
 } from '../../_internal/api/marketplace.gen';
 import { useGenerateSellTransaction } from '../useGenerateSellTransaction';
 
@@ -53,11 +54,13 @@ describe('useGenerateSellTransaction', () => {
 			    {
 			      "data": "0x...",
 			      "id": "tokenApproval",
-			      "post": {
-			        "body": {},
-			        "endpoint": "/api/order",
-			        "method": "POST",
-			      },
+			      "price": "0",
+			      "to": "0x1234567890123456789012345678901234567890",
+			      "value": "0",
+			    },
+			    {
+			      "data": "0x...",
+			      "id": "sell",
 			      "price": "0",
 			      "to": "0x1234567890123456789012345678901234567890",
 			      "value": "0",
@@ -91,7 +94,7 @@ describe('useGenerateSellTransaction', () => {
 
 		await waitFor(() => {
 			expect(mockOnSuccess).toHaveBeenCalledWith(
-				mockSteps,
+				createMockSteps([StepType.tokenApproval, StepType.sell]),
 				mockTransactionProps,
 				undefined,
 			);

--- a/sdk/src/react/hooks/useGenerateOfferTransaction.tsx
+++ b/sdk/src/react/hooks/useGenerateOfferTransaction.tsx
@@ -5,8 +5,10 @@ import {
 	type CreateReq,
 	type GenerateOfferTransactionArgs,
 	type Step,
+	type WalletKind,
 	getMarketplaceClient,
 } from '../_internal';
+import { useWallet } from '../_internal/wallet/useWallet';
 import { useConfig } from './useConfig';
 
 export type UseGenerateOfferTransactionArgs = {
@@ -29,10 +31,12 @@ export const generateOfferTransaction = async (
 	params: GenerateOfferTransactionProps,
 	config: SdkConfig,
 	chainId: number,
+	walletKind?: WalletKind,
 ) => {
 	const args = {
 		...params,
 		offer: { ...params.offer, expiry: dateToUnixTime(params.offer.expiry) },
+		walletType: walletKind,
 	} satisfies GenerateOfferTransactionArgs;
 	const marketplaceClient = getMarketplaceClient(chainId, config);
 	return (await marketplaceClient.generateOfferTransaction(args)).steps;
@@ -42,11 +46,17 @@ export const useGenerateOfferTransaction = (
 	params: UseGenerateOfferTransactionArgs,
 ) => {
 	const config = useConfig();
+	const { wallet } = useWallet();
 
 	const { mutate, mutateAsync, ...result } = useMutation({
 		onSuccess: params.onSuccess,
 		mutationFn: (args: GenerateOfferTransactionProps) =>
-			generateOfferTransaction(args, config, params.chainId),
+			generateOfferTransaction(
+				args,
+				config,
+				params.chainId,
+				wallet?.walletKind,
+			),
 	});
 
 	return {

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -4,7 +4,7 @@ import { createMockWallet } from '@test/mocks/wallet';
 import { zeroAddress } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMakeOfferModal } from '..';
-import { ContractType, OrderbookKind } from '../../../../_internal';
+import { ContractType, OrderbookKind, WalletKind } from '../../../../_internal';
 import * as walletModule from '../../../../_internal/wallet/useWallet';
 import { useGenerateOfferTransaction } from '../../../../hooks';
 import { MakeOfferModal } from '../Modal';
@@ -40,6 +40,7 @@ describe('MakeOfferModal', () => {
 		// Reset all mocks
 		vi.clearAllMocks();
 		vi.resetAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	it('should render', () => {
@@ -52,5 +53,62 @@ describe('MakeOfferModal', () => {
 		expect(modal).toBeDefined();
 
 		modal.unmount();
+	});
+
+	it('should show main button if there is no approval step', async () => {
+		// Mock sequence wallet
+		const sequenceWallet = {
+			...mockWallet,
+			walletKind: WalletKind.sequence,
+		};
+		vi.spyOn(walletModule, 'useWallet').mockReturnValue({
+			wallet: sequenceWallet,
+			isLoading: false,
+			isError: false,
+		});
+
+		// Render the modal
+		const { result } = renderHook(() => useMakeOfferModal());
+		result.current.show(defaultArgs);
+
+		const { queryByText } = render(<MakeOfferModal />);
+
+		// Wait for the component to update
+		await waitFor(() => {
+			// The Approve TOKEN button should not exist
+			const approveButton = queryByText('Approve TOKEN');
+			expect(approveButton).toBeNull();
+
+			const makeOfferButton = queryByText('Make offer');
+			expect(makeOfferButton).toBeDefined();
+		});
+	});
+
+	it('(non-sequence wallets) should show approve token button if there is an approval step, disable main button', async () => {
+		const nonSequenceWallet = {
+			...mockWallet,
+			walletKind: 'unknown' as WalletKind,
+		};
+		vi.spyOn(walletModule, 'useWallet').mockReturnValue({
+			wallet: nonSequenceWallet,
+			isLoading: false,
+			isError: false,
+		});
+
+		// Render the modal
+		const { result } = renderHook(() => useMakeOfferModal());
+		result.current.show(defaultArgs);
+
+		const { getByText } = render(<MakeOfferModal />);
+
+		await waitFor(() => {
+			// find the Approve TOKEN button
+			const approveButton = getByText('Approve TOKEN');
+			expect(approveButton).toBeDefined();
+
+			// main button is disabled when approval step exists
+			const makeOfferButton = getByText('Make offer');
+			expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
+		});
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -1,13 +1,13 @@
-import { cleanup, render, renderHook, waitFor } from '@test';
-import { TEST_COLLECTIBLE } from '@test/const';
+import { cleanup, fireEvent, render, renderHook, waitFor } from '@test';
+import { TEST_COLLECTIBLE, USDC_ADDRESS } from '@test/const';
 import { createMockWallet } from '@test/mocks/wallet';
-import { zeroAddress } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMakeOfferModal } from '..';
-import { ContractType, OrderbookKind, WalletKind } from '../../../../_internal';
+import { WalletKind } from '../../../../_internal';
+import type { Currency } from '../../../../_internal/api/marketplace.gen';
 import * as walletModule from '../../../../_internal/wallet/useWallet';
-import { useGenerateOfferTransaction } from '../../../../hooks';
 import { MakeOfferModal } from '../Modal';
+import { makeOfferModal$ } from '../store';
 
 const defaultArgs = {
 	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
@@ -15,24 +15,7 @@ const defaultArgs = {
 	collectibleId: TEST_COLLECTIBLE.collectibleId,
 };
 
-const mockOffer = {
-	tokenId: '1',
-	quantity: '1',
-	expiry: new Date('2024-12-31'),
-	currencyAddress: zeroAddress,
-	pricePerToken: '1000000000000000000',
-};
-
-const mockTransactionProps = {
-	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
-	maker: zeroAddress,
-	contractType: ContractType.ERC721,
-	orderbook: OrderbookKind.sequence_marketplace_v2,
-	offer: mockOffer,
-};
-
 describe('MakeOfferModal', () => {
-	const mockOnSuccess = vi.fn();
 	const mockWallet = createMockWallet();
 
 	beforeEach(() => {
@@ -41,18 +24,6 @@ describe('MakeOfferModal', () => {
 		vi.clearAllMocks();
 		vi.resetAllMocks();
 		vi.restoreAllMocks();
-	});
-
-	it('should render', () => {
-		const { result } = renderHook(() => useMakeOfferModal());
-
-		result.current.show(defaultArgs);
-
-		const modal = render(<MakeOfferModal />);
-
-		expect(modal).toBeDefined();
-
-		modal.unmount();
 	});
 
 	it('should show main button if there is no approval step', async () => {
@@ -110,5 +81,76 @@ describe('MakeOfferModal', () => {
 			const makeOfferButton = getByText('Make offer');
 			expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
 		});
+	});
+
+	it('should show spinner on approval button when executing', async () => {
+		const { result } = renderHook(() => useMakeOfferModal());
+		result.current.show(defaultArgs);
+
+		// Set steps through the store
+		makeOfferModal$.set({
+			...defaultArgs,
+			isOpen: true,
+			offerPrice: {
+				amountRaw: '1000',
+				currency: {
+					chainId: 1,
+					contractAddress: USDC_ADDRESS,
+					status: 'active',
+					name: 'Test Currency',
+					symbol: 'TEST',
+					decimals: 18,
+					imageUrl: '',
+					exchangeRate: 1,
+					defaultChainCurrency: false,
+					nativeCurrency: false,
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				} as Currency,
+			},
+			offerPriceChanged: true,
+			quantity: '1',
+			invalidQuantity: false,
+			expiry: new Date(),
+			collectionType: undefined,
+			steps: {
+				approval: {
+					exist: true,
+					isExecuting: false,
+					execute: () => Promise.resolve(),
+				},
+				transaction: {
+					exist: true,
+					isExecuting: false,
+					execute: () => Promise.resolve(),
+				},
+			},
+			offerIsBeingProcessed: false,
+			callbacks: undefined,
+			orderbookKind: undefined,
+			open: expect.any(Function),
+			close: expect.any(Function),
+		});
+
+		const { getByText } = render(<MakeOfferModal />);
+
+		await waitFor(() => {
+			expect(getByText('Make an offer')).toBeDefined();
+			expect(getByText('Approve TOKEN')).toBeDefined();
+		});
+
+		const approvalButton = getByText('Approve TOKEN');
+		const makeOfferButton = getByText('Make offer');
+		// approve button is enabled
+		expect(approvalButton.closest('button')).not.toHaveAttribute('disabled');
+		// main button is disabled when approval step exists
+		expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
+
+		fireEvent.click(approvalButton);
+		waitFor(() => {
+			expect(makeOfferModal$.steps.approval.isExecuting.get()).toBe(true);
+		});
+		// spinner should be shown
+		expect(approvalButton.querySelector('.animate-spin')).toBeDefined();
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -1,6 +1,13 @@
-import { cleanup } from '@test';
+import { cleanup, render, renderHook, waitFor } from '@test';
 import { TEST_COLLECTIBLE } from '@test/const';
-import { beforeEach, describe, vi } from 'vitest';
+import { zeroAddress } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnect } from 'wagmi';
+import { useMakeOfferModal } from '..';
+import { ContractType, OrderbookKind } from '../../../../_internal';
+import { useWallet } from '../../../../_internal/wallet/useWallet';
+import { useGenerateOfferTransaction } from '../../../../hooks';
+import { MakeOfferModal } from '../Modal';
 
 const defaultArgs = {
 	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
@@ -8,11 +15,111 @@ const defaultArgs = {
 	collectibleId: TEST_COLLECTIBLE.collectibleId,
 };
 
-describe.skip('MakeOfferModal', () => {
+const mockOffer = {
+	tokenId: '1',
+	quantity: '1',
+	expiry: new Date('2024-12-31'),
+	currencyAddress: zeroAddress,
+	pricePerToken: '1000000000000000000',
+};
+
+const mockTransactionProps = {
+	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
+	maker: zeroAddress,
+	contractType: ContractType.ERC721,
+	orderbook: OrderbookKind.sequence_marketplace_v2,
+	offer: mockOffer,
+};
+
+describe('MakeOfferModal', () => {
+	const mockOnSuccess = vi.fn();
+
 	beforeEach(() => {
 		cleanup();
 		// Reset all mocks
 		vi.clearAllMocks();
 		vi.resetAllMocks();
+	});
+
+	it('should render', () => {
+		const { result } = renderHook(() => useMakeOfferModal());
+
+		result.current.show(defaultArgs);
+
+		const modal = render(<MakeOfferModal />);
+
+		expect(modal).toBeDefined();
+
+		modal.unmount();
+	});
+
+	describe('non-sequence wallets', () => {
+		it('should have a tokenApproval step if an approval is required', async () => {
+			const { result: connectResult } = renderHook(() => useConnect());
+			const { result: walletResult } = renderHook(() => useWallet());
+			const { result: makeOfferResult } = renderHook(() => useMakeOfferModal());
+
+			// .connect without options defaults to non-sequence wallets, which, if an approval step is required, we will see it in response of the useGenerateOfferTransaction hook
+			connectResult.current.connect({
+				connector: connectResult.current.connectors[0],
+			});
+
+			expect(walletResult.current.isLoading).toBe(true);
+
+			await waitFor(() => {
+				expect(walletResult.current.isLoading).toBe(false);
+			});
+
+			makeOfferResult.current.show(defaultArgs);
+
+			const modal = render(<MakeOfferModal />);
+
+			expect(modal).toBeDefined();
+
+			const { result } = renderHook(() =>
+				useGenerateOfferTransaction({
+					...defaultArgs,
+					onSuccess: mockOnSuccess,
+				}),
+			);
+
+			await result.current.generateOfferTransactionAsync(mockTransactionProps);
+
+			// there's a tokenApproval step and a createOffer step
+			expect(mockOnSuccess.mock.lastCall).toMatchInlineSnapshot(`
+				[
+				  [
+				    {
+				      "data": "0x...",
+				      "id": "tokenApproval",
+				      "price": "0",
+				      "to": "0x1234567890123456789012345678901234567890",
+				      "value": "0",
+				    },
+				    {
+				      "data": "0x...",
+				      "id": "createOffer",
+				      "price": "0",
+				      "to": "0x1234567890123456789012345678901234567890",
+				      "value": "0",
+				    },
+				  ],
+				  {
+				    "collectionAddress": "0xbabafdd8045740449a42b788a26e9b3a32f88ac1",
+				    "contractType": "ERC721",
+				    "maker": "0x0000000000000000000000000000000000000000",
+				    "offer": {
+				      "currencyAddress": "0x0000000000000000000000000000000000000000",
+				      "expiry": 2024-12-31T00:00:00.000Z,
+				      "pricePerToken": "1000000000000000000",
+				      "quantity": "1",
+				      "tokenId": "1",
+				    },
+				    "orderbook": "sequence_marketplace_v2",
+				  },
+				  undefined,
+				]
+			`);
+		});
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -1,13 +1,11 @@
-import { cleanup, fireEvent, render, renderHook, waitFor } from '@test';
-import { TEST_COLLECTIBLE, USDC_ADDRESS } from '@test/const';
+import { cleanup, render, renderHook, waitFor } from '@test';
+import { TEST_COLLECTIBLE } from '@test/const';
 import { createMockWallet } from '@test/mocks/wallet';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMakeOfferModal } from '..';
 import { WalletKind } from '../../../../_internal';
-import type { Currency } from '../../../../_internal/api/marketplace.gen';
 import * as walletModule from '../../../../_internal/wallet/useWallet';
 import { MakeOfferModal } from '../Modal';
-import { makeOfferModal$ } from '../store';
 
 const defaultArgs = {
 	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
@@ -81,76 +79,5 @@ describe('MakeOfferModal', () => {
 			const makeOfferButton = getByText('Make offer');
 			expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
 		});
-	});
-
-	it('should show spinner on approval button when executing', async () => {
-		const { result } = renderHook(() => useMakeOfferModal());
-		result.current.show(defaultArgs);
-
-		// Set steps through the store
-		makeOfferModal$.set({
-			...defaultArgs,
-			isOpen: true,
-			offerPrice: {
-				amountRaw: '1000',
-				currency: {
-					chainId: 1,
-					contractAddress: USDC_ADDRESS,
-					status: 'active',
-					name: 'Test Currency',
-					symbol: 'TEST',
-					decimals: 18,
-					imageUrl: '',
-					exchangeRate: 1,
-					defaultChainCurrency: false,
-					nativeCurrency: false,
-					createdAt: new Date().toISOString(),
-					updatedAt: new Date().toISOString(),
-				} as Currency,
-			},
-			offerPriceChanged: true,
-			quantity: '1',
-			invalidQuantity: false,
-			expiry: new Date(),
-			collectionType: undefined,
-			steps: {
-				approval: {
-					exist: true,
-					isExecuting: false,
-					execute: () => Promise.resolve(),
-				},
-				transaction: {
-					exist: true,
-					isExecuting: false,
-					execute: () => Promise.resolve(),
-				},
-			},
-			offerIsBeingProcessed: false,
-			callbacks: undefined,
-			orderbookKind: undefined,
-			open: expect.any(Function),
-			close: expect.any(Function),
-		});
-
-		const { getByText } = render(<MakeOfferModal />);
-
-		await waitFor(() => {
-			expect(getByText('Make an offer')).toBeDefined();
-			expect(getByText('Approve TOKEN')).toBeDefined();
-		});
-
-		const approvalButton = getByText('Approve TOKEN');
-		const makeOfferButton = getByText('Make offer');
-		// approve button is enabled
-		expect(approvalButton.closest('button')).not.toHaveAttribute('disabled');
-		// main button is disabled when approval step exists
-		expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
-
-		fireEvent.click(approvalButton);
-		waitFor(() => {
-			expect(makeOfferModal$.steps.approval.isExecuting.get()).toBe(true);
-		});
-		// spinner should be shown
-		expect(approvalButton.querySelector('.animate-spin')).toBeDefined();
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -1,30 +1,11 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@test';
-import { zeroAddress } from 'viem';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MakeOfferModal } from '../Modal';
-import { makeOfferModal$ } from '../store';
-
-// TODO: This should be moved to a shared test file
-vi.mock(import('../../../../hooks'), async (importOriginal) => {
-	const actual = await importOriginal();
-	return {
-		...actual,
-		useCollectible: vi.fn(actual.useCollectible),
-		useCollection: vi.fn(actual.useCollection),
-		useCurrencies: vi.fn(actual.useCurrencies),
-		useMarketplaceConfig: vi.fn(actual.useMarketplaceConfig),
-		useLowestListing: vi.fn(actual.useLowestListing),
-	};
-});
-
-vi.mock('@0xsequence/kit', () => ({
-	useWaasFeeOptions: vi.fn().mockReturnValue([]),
-}));
+import { cleanup } from '@test';
+import { TEST_COLLECTIBLE } from '@test/const';
+import { beforeEach, describe, vi } from 'vitest';
 
 const defaultArgs = {
-	collectionAddress: zeroAddress,
-	chainId: 1,
-	collectibleId: '1',
+	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
+	chainId: TEST_COLLECTIBLE.chainId,
+	collectibleId: TEST_COLLECTIBLE.collectibleId,
 };
 
 describe.skip('MakeOfferModal', () => {
@@ -33,87 +14,5 @@ describe.skip('MakeOfferModal', () => {
 		// Reset all mocks
 		vi.clearAllMocks();
 		vi.resetAllMocks();
-	});
-
-	it('should not render when modal is closed', () => {
-		render(<MakeOfferModal />);
-		expect(screen.queryByText('Make an offer')).toBeNull();
-	});
-
-	it('should render loading state', () => {
-		makeOfferModal$.open(defaultArgs);
-
-		render(<MakeOfferModal />);
-		const loadingModal = screen.getByTestId('loading-modal');
-		expect(loadingModal).toBeVisible();
-	});
-
-	it.skip('should render error state', async () => {
-		// @ts-expect-error - TODO: Add a common mock object with the correct shape
-		vi.mocked(hooks.useCollection).mockReturnValue({
-			data: undefined,
-			isLoading: false,
-			isError: true,
-		});
-
-		makeOfferModal$.open(defaultArgs);
-
-		render(<MakeOfferModal />);
-		const errorModal = await screen.findByTestId('error-modal');
-		expect(errorModal).toBeVisible();
-	});
-
-	it.skip('should render main form when data is loaded', async () => {
-		makeOfferModal$.open(defaultArgs);
-
-		render(<MakeOfferModal />);
-
-		expect(await screen.findByText('Enter price')).toBeInTheDocument();
-	});
-
-	it.skip('should reset store values when modal is closed and reopened', () => {
-		// Open modal first time
-		makeOfferModal$.open(defaultArgs);
-
-		// Set some values in the store
-		makeOfferModal$.offerPrice.amountRaw.set('1000000000000000000');
-		makeOfferModal$.expiry.set(new Date());
-
-		// Close modal
-		makeOfferModal$.close();
-
-		// Verify store is reset
-		expect(makeOfferModal$.offerPrice.amountRaw.get()).toBe('0');
-		expect(makeOfferModal$.expiry.get()).toBeDefined();
-
-		// Reopen modal
-		makeOfferModal$.open(defaultArgs);
-
-		// Verify store has default values
-		expect(makeOfferModal$.offerPrice.amountRaw.get()).toBe('0');
-		expect(makeOfferModal$.expiry.get()).toBeDefined();
-	});
-
-	it.skip('should update state based on price input', async () => {
-		makeOfferModal$.open(defaultArgs);
-
-		render(<MakeOfferModal />);
-
-		// Initial price should be 0
-		expect(makeOfferModal$.offerPrice.amountRaw.get()).toBe('0');
-
-		// Find and interact with price input
-
-		const priceInput = await screen.findByRole('textbox', {
-			name: 'Enter price',
-		});
-		expect(priceInput).toBeInTheDocument();
-
-		fireEvent.change(priceInput, { target: { value: '1.5' } });
-
-		// Wait for the state to update and verify it's not 0 anymore
-		await waitFor(() => {
-			expect(makeOfferModal$.offerPrice.amountRaw.get()).not.toBe('0');
-		});
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -1,11 +1,11 @@
 import { cleanup, render, renderHook, waitFor } from '@test';
 import { TEST_COLLECTIBLE } from '@test/const';
+import { createMockWallet } from '@test/mocks/wallet';
 import { zeroAddress } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useConnect } from 'wagmi';
 import { useMakeOfferModal } from '..';
 import { ContractType, OrderbookKind } from '../../../../_internal';
-import { useWallet } from '../../../../_internal/wallet/useWallet';
+import * as walletModule from '../../../../_internal/wallet/useWallet';
 import { useGenerateOfferTransaction } from '../../../../hooks';
 import { MakeOfferModal } from '../Modal';
 
@@ -33,6 +33,7 @@ const mockTransactionProps = {
 
 describe('MakeOfferModal', () => {
 	const mockOnSuccess = vi.fn();
+	const mockWallet = createMockWallet();
 
 	beforeEach(() => {
 		cleanup();
@@ -51,75 +52,5 @@ describe('MakeOfferModal', () => {
 		expect(modal).toBeDefined();
 
 		modal.unmount();
-	});
-
-	describe('non-sequence wallets', () => {
-		it('should have a tokenApproval step if an approval is required', async () => {
-			const { result: connectResult } = renderHook(() => useConnect());
-			const { result: walletResult } = renderHook(() => useWallet());
-			const { result: makeOfferResult } = renderHook(() => useMakeOfferModal());
-
-			// .connect without options defaults to non-sequence wallets, which, if an approval step is required, we will see it in response of the useGenerateOfferTransaction hook
-			connectResult.current.connect({
-				connector: connectResult.current.connectors[0],
-			});
-
-			expect(walletResult.current.isLoading).toBe(true);
-
-			await waitFor(() => {
-				expect(walletResult.current.isLoading).toBe(false);
-			});
-
-			makeOfferResult.current.show(defaultArgs);
-
-			const modal = render(<MakeOfferModal />);
-
-			expect(modal).toBeDefined();
-
-			const { result } = renderHook(() =>
-				useGenerateOfferTransaction({
-					...defaultArgs,
-					onSuccess: mockOnSuccess,
-				}),
-			);
-
-			await result.current.generateOfferTransactionAsync(mockTransactionProps);
-
-			// there's a tokenApproval step and a createOffer step
-			expect(mockOnSuccess.mock.lastCall).toMatchInlineSnapshot(`
-				[
-				  [
-				    {
-				      "data": "0x...",
-				      "id": "tokenApproval",
-				      "price": "0",
-				      "to": "0x1234567890123456789012345678901234567890",
-				      "value": "0",
-				    },
-				    {
-				      "data": "0x...",
-				      "id": "createOffer",
-				      "price": "0",
-				      "to": "0x1234567890123456789012345678901234567890",
-				      "value": "0",
-				    },
-				  ],
-				  {
-				    "collectionAddress": "0xbabafdd8045740449a42b788a26e9b3a32f88ac1",
-				    "contractType": "ERC721",
-				    "maker": "0x0000000000000000000000000000000000000000",
-				    "offer": {
-				      "currencyAddress": "0x0000000000000000000000000000000000000000",
-				      "expiry": 2024-12-31T00:00:00.000Z,
-				      "pricePerToken": "1000000000000000000",
-				      "quantity": "1",
-				      "tokenId": "1",
-				    },
-				    "orderbook": "sequence_marketplace_v2",
-				  },
-				  undefined,
-				]
-			`);
-		});
 	});
 });

--- a/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/__tests__/Modal.test.tsx
@@ -3,14 +3,31 @@ import { TEST_COLLECTIBLE } from '@test/const';
 import { createMockWallet } from '@test/mocks/wallet';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMakeOfferModal } from '..';
-import { WalletKind } from '../../../../_internal';
+import { CurrencyStatus, WalletKind } from '../../../../_internal';
 import * as walletModule from '../../../../_internal/wallet/useWallet';
 import { MakeOfferModal } from '../Modal';
+import { makeOfferModal$ } from '../store';
 
 const defaultArgs = {
 	collectionAddress: TEST_COLLECTIBLE.collectionAddress,
 	chainId: TEST_COLLECTIBLE.chainId,
 	collectibleId: TEST_COLLECTIBLE.collectibleId,
+};
+
+// Mock currency object with all required properties
+const mockCurrency = {
+	chainId: 1,
+	contractAddress: '0x123',
+	status: CurrencyStatus.active,
+	name: 'Test Token',
+	symbol: 'TEST',
+	decimals: 18,
+	imageUrl: 'https://example.com/test.png',
+	exchangeRate: 1,
+	defaultChainCurrency: false,
+	nativeCurrency: false,
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
 };
 
 describe('MakeOfferModal', () => {
@@ -79,5 +96,54 @@ describe('MakeOfferModal', () => {
 			const makeOfferButton = getByText('Make offer');
 			expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
 		});
+	});
+
+	it('should show/hide CTAs based on approval step existence in store', async () => {
+		// test case 1: approval.exist = true
+		makeOfferModal$.open(defaultArgs);
+		makeOfferModal$.offerPrice.set({
+			amountRaw: '1000000000000000000',
+			currency: mockCurrency,
+		});
+		makeOfferModal$.offerPriceChanged.set(true);
+		makeOfferModal$.steps.approval.exist.set(true);
+
+		const { getByText, unmount } = render(<MakeOfferModal />);
+
+		await waitFor(() => {
+			// Approve TOKEN button should be visible
+			const approveButton = getByText('Approve TOKEN');
+			expect(approveButton).toBeDefined();
+
+			// Make offer button should be disabled
+			const makeOfferButton = getByText('Make offer');
+			expect(makeOfferButton.closest('button')).toHaveAttribute('disabled');
+		});
+
+		unmount();
+		cleanup();
+
+		// test case 2: approval.exist = false
+		makeOfferModal$.open(defaultArgs);
+		makeOfferModal$.offerPrice.set({
+			amountRaw: '1000000000000000000',
+			currency: mockCurrency,
+		});
+		makeOfferModal$.offerPriceChanged.set(true);
+		makeOfferModal$.steps.approval.exist.set(false);
+
+		const { queryByText, getByText: getByText2 } = render(<MakeOfferModal />);
+
+		await waitFor(() => {
+			// Approve TOKEN button should not exist or be hidden
+			const approveButton = queryByText('Approve TOKEN');
+			expect(approveButton).toBeNull();
+
+			// Make offer button should be enabled
+			const makeOfferButton = getByText2('Make offer');
+			expect(makeOfferButton.closest('button')).not.toHaveAttribute('disabled');
+		});
+
+		makeOfferModal$.close();
 	});
 });

--- a/sdk/src/react/ui/modals/_internal/components/actionModal/ActionModal.test.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/actionModal/ActionModal.test.tsx
@@ -175,4 +175,112 @@ describe('ActionModal', () => {
 			});
 		});
 	});
+
+	describe('CTA buttons', () => {
+		it('should call onClick when CTA button is clicked', async () => {
+			const onClick = vi.fn();
+			render(
+				<ActionModal
+					{...defaultProps}
+					ctas={[{ label: 'Click Me', onClick, testid: 'cta-button' }]}
+				/>,
+			);
+
+			const button = screen.getByTestId('cta-button');
+			fireEvent.click(button);
+
+			await waitFor(() => {
+				expect(onClick).toHaveBeenCalled();
+			});
+		});
+
+		it('should disable the button when disabled prop is true', () => {
+			render(
+				<ActionModal
+					{...defaultProps}
+					ctas={[
+						{
+							label: 'Disabled Button',
+							onClick: mockOnClick,
+							disabled: true,
+							testid: 'disabled-button',
+						},
+					]}
+				/>,
+			);
+
+			const button = screen.getByTestId('disabled-button');
+			expect(button).toBeDisabled();
+
+			fireEvent.click(button);
+			expect(mockOnClick).not.toHaveBeenCalled();
+		});
+
+		it('should show spinner when pending prop is true', () => {
+			render(
+				<ActionModal
+					{...defaultProps}
+					ctas={[
+						{
+							label: 'Loading Button',
+							onClick: mockOnClick,
+							pending: true,
+							testid: 'pending-button',
+						},
+					]}
+				/>,
+			);
+
+			expect(screen.getByTestId('pending-button')).toBeInTheDocument();
+			expect(screen.getByTestId('pending-button-spinner')).toBeInTheDocument(); // wrapper of spinner has data-testid of {testid}-spinner
+		});
+
+		it('should not render hidden buttons', () => {
+			render(
+				<ActionModal
+					{...defaultProps}
+					ctas={[
+						{
+							label: 'Visible Button',
+							onClick: vi.fn(),
+							testid: 'visible-button',
+						},
+						{
+							label: 'Hidden Button',
+							onClick: vi.fn(),
+							hidden: true,
+							testid: 'hidden-button',
+						},
+					]}
+				/>,
+			);
+
+			expect(screen.getByTestId('visible-button')).toBeInTheDocument();
+			expect(screen.queryByTestId('hidden-button')).not.toBeInTheDocument();
+		});
+
+		it('should render multiple CTA buttons', () => {
+			render(
+				<ActionModal
+					{...defaultProps}
+					ctas={[
+						{
+							label: 'Primary CTA',
+							onClick: vi.fn(),
+							testid: 'primary-cta',
+						},
+						{
+							label: 'Secondary CTA',
+							onClick: vi.fn(),
+							variant: 'secondary',
+							testid: 'secondary-cta',
+						},
+					]}
+				/>,
+			);
+
+			expect(screen.getByTestId('primary-cta')).toBeInTheDocument();
+			expect(screen.getByTestId('secondary-cta')).toBeInTheDocument();
+		});
+	});
 });

--- a/sdk/src/react/ui/modals/_internal/components/actionModal/ActionModal.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/actionModal/ActionModal.tsx
@@ -126,7 +126,11 @@ export const ActionModal = observer(
 											data-testid={cta.testid}
 											label={
 												<div className="flex items-center justify-center gap-2">
-													{cta.pending && <Spinner size="sm" />}
+													{cta.pending && (
+														<div data-testid={`${cta.testid}-spinner`}>
+															<Spinner size="sm" />
+														</div>
+													)}
 
 													{cta.label}
 												</div>


### PR DESCRIPTION
☑️ Non-sequence-wallets - Should make request to GenerateOfferTransaction when mounted, show Approve TOKEN button if there is an approval step, disable Make offer button accordingly,  (_**sdk/src/react/hooks/__tests__/useGenerateOfferTransaction.test.tsx takes care of it**_)

☑️ Sequence Wallets - Should make request to GenerateOfferTransaction when mounted (user is not taking care of token approval) (_**sdk/src/react/hooks/__tests__/useGenerateOfferTransaction.test.tsx takes care of it**_),

☑️  Should handle disability of buttons according to balance sufficiency.

> this feels it belongs to `PriceInput`. We just need to test if it handles its `checkBalance` callback prop ([See updated `PriceInput` tests](https://github.com/0xsequence/marketplace-sdk/pull/291)):  

```
       <PriceInput
            ....
            checkBalance={{
            enabled: true,
            callback: (state) => setInsufficientBalance(state),
          }}
```

☑️ Clicking on Approve TOKEN: Make request to GenerateOfferTransaction to get new steps with current inputs, put a spinner on Approve TOKEN button, set it disabled. Hide it when txn receipt received, enable Make offer button.
> _Half of it is tested on `ActionModal.test.ts` ([commit](https://github.com/0xsequence/marketplace-sdk/pull/288/commits/c9409c1ed454fd174c0cfc84067cb110041f96c8))_