### PR TITLE
Improve query invalidation and refetching after offer/listing cancellation

### DIFF
--- a/playgrounds/shared/src/components/activitiesTable/Body.tsx
+++ b/playgrounds/shared/src/components/activitiesTable/Body.tsx
@@ -115,10 +115,7 @@ const ActivitiesTableBody = ({
 	return (
 		<Table.Body>
 			{displayActivities.map((activity) => (
-				<ActivityRow
-					key={`${activity.createdAt}-${activity.action}-${activity.from}-${activity.to}`}
-					activity={activity}
-				/>
+				<ActivityRow key={activity.uniqueHash} activity={activity} />
 			))}
 		</Table.Body>
 	);

--- a/sdk/src/react/hooks/useAutoSelectFeeOption.tsx
+++ b/sdk/src/react/hooks/useAutoSelectFeeOption.tsx
@@ -1,7 +1,7 @@
 import { type Address, zeroAddress } from 'viem';
 
 import { useChain } from '@0xsequence/connect';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useAccount } from 'wagmi';
 import type { FeeOption } from '../../types/waas-types';
 import { useCollectionBalanceDetails } from './useCollectionBalanceDetails';
@@ -19,6 +19,7 @@ type UseAutoSelectFeeOptionArgs = {
 		options: FeeOption[] | undefined;
 		chainId: number;
 	};
+	enabled?: boolean;
 };
 
 /**
@@ -87,6 +88,7 @@ type UseAutoSelectFeeOptionArgs = {
  */
 export function useAutoSelectFeeOption({
 	pendingFeeOptionConfirmation,
+	enabled,
 }: UseAutoSelectFeeOptionArgs) {
 	const { address: userAddress } = useAccount();
 
@@ -110,7 +112,8 @@ export function useAutoSelectFeeOption({
 			omitNativeBalances: false,
 		},
 		query: {
-			enabled: !!pendingFeeOptionConfirmation.options && !!userAddress,
+			enabled:
+				!!pendingFeeOptionConfirmation.options && !!userAddress && enabled,
 		},
 	});
 	const chain = useChain(pendingFeeOptionConfirmation.chainId);
@@ -131,7 +134,11 @@ export function useAutoSelectFeeOption({
 		})),
 	];
 
-	console.debug('currency balances', combinedBalances);
+	useEffect(() => {
+		if (combinedBalances) {
+			console.debug('currency balances', combinedBalances);
+		}
+	}, [combinedBalances]);
 
 	const autoSelectedOption = useCallback(async () => {
 		if (!userAddress) {

--- a/sdk/src/react/hooks/useCancelOrder.tsx
+++ b/sdk/src/react/hooks/useCancelOrder.tsx
@@ -54,6 +54,7 @@ export const useCancelOrder = ({
 					options: undefined,
 					chainId,
 				},
+		enabled: !!pendingFeeOptionConfirmation,
 	});
 
 	useEffect(() => {

--- a/sdk/src/react/hooks/useCancelTransactionSteps.tsx
+++ b/sdk/src/react/hooks/useCancelTransactionSteps.tsx
@@ -20,6 +20,10 @@ import type { ModalCallbacks } from '../ui/modals/_internal/types';
 import type { TransactionStep } from './useCancelOrder';
 import { useConfig } from './useConfig';
 import { useGenerateCancelTransaction } from './useGenerateCancelTransaction';
+import {
+	invalidateQueriesOnCancel,
+	updateQueriesOnCancel,
+} from './util/optimisticCancelUpdates';
 
 interface UseCancelTransactionStepsArgs {
 	collectionAddress: string;
@@ -156,9 +160,12 @@ export const useCancelTransactionSteps = ({
 
 					if (onSuccess && typeof onSuccess === 'function') {
 						onSuccess({ hash });
-					}
 
-					queryClient.invalidateQueries();
+						updateQueriesOnCancel({
+							orderId,
+							queryClient,
+						});
+					}
 
 					setSteps((prev) => ({
 						...prev,
@@ -172,9 +179,12 @@ export const useCancelTransactionSteps = ({
 
 				if (onSuccess && typeof onSuccess === 'function') {
 					onSuccess({ orderId: reservoirOrderId });
-				}
 
-				queryClient.invalidateQueries();
+					updateQueriesOnCancel({
+						orderId: reservoirOrderId,
+						queryClient,
+					});
+				}
 
 				setSteps((prev) => ({
 					...prev,
@@ -182,6 +192,10 @@ export const useCancelTransactionSteps = ({
 				}));
 			}
 		} catch (error) {
+			invalidateQueriesOnCancel({
+				queryClient,
+			});
+
 			setSteps((prev) => ({
 				...prev,
 				isExecuting: false,

--- a/sdk/src/react/hooks/util/optimisticCancelUpdates.ts
+++ b/sdk/src/react/hooks/util/optimisticCancelUpdates.ts
@@ -1,0 +1,115 @@
+import type { QueryClient } from '@tanstack/react-query';
+import {
+	type GetCountOfListingsForCollectibleReturn,
+	type GetCountOfOffersForCollectibleReturn,
+	type ListListingsForCollectibleReturn,
+	type ListOffersForCollectibleReturn,
+	collectableKeys,
+} from '../../_internal';
+
+const SECOND = 1000;
+
+interface OptimisticCancelUpdatesParams {
+	orderId: string;
+	queryClient: QueryClient;
+}
+
+export const updateQueriesOnCancel = ({
+	orderId,
+	queryClient,
+}: OptimisticCancelUpdatesParams) => {
+	queryClient.setQueriesData(
+		{ queryKey: collectableKeys.offersCount, exact: false },
+		(oldData: GetCountOfOffersForCollectibleReturn | undefined) => {
+			if (!oldData) return { count: 0 };
+			return { count: Math.max(0, oldData.count - 1) };
+		},
+	);
+
+	console.log('query client ', queryClient, 'orderId', orderId);
+
+	// remove the offer with matching orderId
+	queryClient.setQueriesData(
+		{ queryKey: collectableKeys.offers, exact: false },
+		(oldData: ListOffersForCollectibleReturn | undefined) => {
+			if (!oldData || !oldData.offers) return oldData;
+			return {
+				...oldData,
+				offers: oldData.offers.filter((offer) => offer.orderId !== orderId),
+			};
+		},
+	);
+
+	// 2 seconds is enough time for new data to be fetched
+	setTimeout(() => {
+		queryClient.invalidateQueries({
+			queryKey: collectableKeys.highestOffers,
+			exact: false,
+		});
+	}, 2 * SECOND);
+
+	queryClient.setQueriesData(
+		{ queryKey: collectableKeys.listingsCount, exact: false },
+		(oldData: GetCountOfListingsForCollectibleReturn | undefined) => {
+			if (!oldData) return { count: 0 };
+			return { count: Math.max(0, oldData.count - 1) };
+		},
+	);
+
+	queryClient.setQueriesData(
+		{ queryKey: collectableKeys.listings, exact: false },
+		(oldData: ListListingsForCollectibleReturn | undefined) => {
+			if (!oldData || !oldData.listings) return oldData;
+			return {
+				...oldData,
+				listings: oldData.listings.filter(
+					(listing) => listing.orderId !== orderId,
+				),
+			};
+		},
+	);
+
+	// 2 seconds is enough time for new data to be fetched
+	setTimeout(() => {
+		queryClient.invalidateQueries({
+			queryKey: collectableKeys.lowestListings,
+			exact: false,
+		});
+	}, 2 * SECOND);
+};
+
+export const invalidateQueriesOnCancel = ({
+	queryClient,
+}: {
+	queryClient: QueryClient;
+}) => {
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.offers,
+		exact: false,
+	});
+
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.offersCount,
+		exact: false,
+	});
+
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.listings,
+		exact: false,
+	});
+
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.listingsCount,
+		exact: false,
+	});
+
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.highestOffers,
+		exact: false,
+	});
+
+	queryClient.invalidateQueries({
+		queryKey: collectableKeys.lowestListings,
+		exact: false,
+	});
+};


### PR DESCRIPTION
[Ticket](https://github.com/0xsequence/issue-tracker/issues/4788)
This improves the reliability of query updates following an offer/listing cancellation by ensuring that stale data (like the highest offer or lowest listing) is not shown after a cancel action.