### PR TITLE
Support waasSettings field

### DIFF
--- a/sdk/src/react/_internal/wagmi/get-connectors.ts
+++ b/sdk/src/react/_internal/wagmi/get-connectors.ts
@@ -113,7 +113,12 @@ export function getWaasConnectors(
 ): Wallet[] {
 	const { projectAccessKey } = config;
 
-	const waasConfigKey = marketplaceConfig.walletOptions.waas?.tenantKey;
+	const waasConfig =
+		marketplaceConfig.walletOptions.waas ||
+		// @ts-expect-error the endpoint sometimes returns the waasSettings instead of waas
+		marketplaceConfig.walletOptions.waasSettings;
+
+	const waasConfigKey = waasConfig.tenantKey;
 
 	if (!waasConfigKey)
 		throw new MissingConfigError(

--- a/sdk/src/react/_internal/wagmi/get-connectors.ts
+++ b/sdk/src/react/_internal/wagmi/get-connectors.ts
@@ -117,11 +117,13 @@ export function getWaasConnectors(
 ): Wallet[] {
 	const { projectAccessKey } = config;
 
-	const waasConfig =
-		marketplaceConfig.walletOptions.waas ||
-		// @ts-expect-error the endpoint sometimes returns the waasSettings instead of waas
-		(marketplaceConfig.walletOptions
-			.waasSettings as MarketplaceWalletWaasSettings);
+	let waasConfig = marketplaceConfig.walletOptions.waas;
+
+	if (!waasConfig) {
+		//@ts-expect-error the endpoint sometimes returns the waasSettings instead of waas
+		const waasSettings = marketplaceConfig.walletOptions.waasSettings;
+		waasConfig = waasSettings as MarketplaceWalletWaasSettings;
+	}
 
 	const waasConfigKey = waasConfig.tenantKey;
 

--- a/sdk/src/react/_internal/wagmi/get-connectors.ts
+++ b/sdk/src/react/_internal/wagmi/get-connectors.ts
@@ -17,7 +17,11 @@ import {
 } from '@0xsequence/connect';
 import React, { type FunctionComponent } from 'react';
 import type { CreateConnectorFn } from 'wagmi';
-import type { Env, SdkConfig } from '../../../types';
+import type {
+	Env,
+	MarketplaceWalletWaasSettings,
+	SdkConfig,
+} from '../../../types';
 import { MissingConfigError } from '../../../utils/_internal/error/transaction';
 import type { MarketplaceConfig } from '../../queries/marketplaceConfig';
 import { MarketplaceWallet } from '../api/builder.gen';
@@ -116,7 +120,8 @@ export function getWaasConnectors(
 	const waasConfig =
 		marketplaceConfig.walletOptions.waas ||
 		// @ts-expect-error the endpoint sometimes returns the waasSettings instead of waas
-		marketplaceConfig.walletOptions.waasSettings;
+		(marketplaceConfig.walletOptions
+			.waasSettings as MarketplaceWalletWaasSettings);
 
 	const waasConfigKey = waasConfig.tenantKey;
 


### PR DESCRIPTION
The lookupMarketplaceConfig sometimes returns the waasSettings instead of waas field name