### PR TITLE
Enhance Media component to support custom fallback content

### DIFF
--- a/playgrounds/react-vite/src/tabs/Collections.tsx
+++ b/playgrounds/react-vite/src/tabs/Collections.tsx
@@ -1,6 +1,7 @@
 import { getNetwork } from '@0xsequence/connect';
 import {
 	Card,
+	CollectionIcon,
 	NetworkImage,
 	Skeleton,
 	Text,
@@ -52,6 +53,7 @@ function CollectionCard({
 				<Media
 					assets={[collection.logoURI]}
 					className="mr-2 h-auto w-10 rounded-full"
+					fallbackContent={<CollectionIcon className="text-text-50" />}
 				/>
 				<div>
 					<Text variant="large" fontWeight="bold" className="mb-1 line-clamp-1">

--- a/sdk/src/react/ui/components/collectible-card/__tests__/Media.test.tsx
+++ b/sdk/src/react/ui/components/collectible-card/__tests__/Media.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@test/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 import * as fetchContentTypeModule from '../../../../../utils/fetchContentType';
 import type { TokenMetadata } from '../../../../_internal';
+import ChessTileImage from '../../../images/chess-tile.png';
 import { Media } from '../media/Media';
 import * as contentTypeUtils from '../media/utils';
 
@@ -260,5 +261,73 @@ describe('Media', () => {
 
 		// Image should become visible
 		expect(imgElement?.className).toContain('visible');
+	});
+
+	it('uses custom fallback content when provided', async () => {
+		const CustomFallback = () => (
+			<div data-testid="custom-fallback">Custom Fallback Content</div>
+		);
+
+		const mockMetadata: Partial<TokenMetadata> = {
+			tokenId: '1',
+			name: 'Test Collectible',
+			image: 'https://example.com/bad-image.png',
+			attributes: [],
+		};
+
+		const { rerender } = render(
+			<Media
+				name="Test Collectible"
+				assets={[mockMetadata.image]}
+				fallbackContent={<CustomFallback />}
+			/>,
+		);
+
+		// Wait for initial content type check
+		await waitFor(() => {
+			const imgElement = screen.getByRole('img');
+			expect(imgElement).toBeInTheDocument();
+		});
+
+		const imgElement = screen.getByRole('img');
+		expect(imgElement).not.toBeNull();
+
+		// Initial image should be the bad image URL
+		expect(imgElement.getAttribute('src')).toBe(
+			'https://example.com/bad-image.png',
+		);
+
+		// Simulate image load error
+		imgElement.dispatchEvent(new Event('error'));
+
+		// After error, the custom fallback should be rendered
+		await waitFor(() => {
+			expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+			expect(screen.getByText('Custom Fallback Content')).toBeInTheDocument();
+		});
+
+		// Test with no assets - should immediately use fallback
+		rerender(
+			<Media
+				name="Test Collectible"
+				assets={[]}
+				fallbackContent={<CustomFallback />}
+			/>,
+		);
+
+		// Should show custom fallback immediately
+		await waitFor(() => {
+			expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+			expect(screen.getByText('Custom Fallback Content')).toBeInTheDocument();
+		});
+
+		// Test with default chess tile fallback when no custom fallback is provided
+		rerender(<Media name="Test Collectible" assets={[]} />);
+
+		await waitFor(() => {
+			const defaultFallbackImg = screen.getByRole('img');
+			expect(defaultFallbackImg).toBeInTheDocument();
+			expect(defaultFallbackImg.getAttribute('src')).toBe(ChessTileImage);
+		});
 	});
 });

--- a/sdk/src/react/ui/components/collectible-card/media/types.ts
+++ b/sdk/src/react/ui/components/collectible-card/media/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 type ContentType = 'image' | 'video' | 'html' | '3d-model' | null;
 
 type ContentTypeState = {
@@ -13,6 +15,7 @@ type MediaProps = {
 	className?: string;
 	supply?: number;
 	isLoading?: boolean;
+	fallbackContent?: ReactNode;
 };
 
 export type { ContentType, ContentTypeState, MediaProps };


### PR DESCRIPTION
https://github.com/0xsequence/issue-tracker/issues/5134

Added fallbackContent prop to allow users to specify custom fallback UI when asset loading fails or no assets are provided. Updated tests to verify custom fallback behavior and default to a placeholder image when necessary.