### PR TITLE
Copy and alias react-day-picker css for Vite ssr

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -46,6 +46,9 @@
 			"types": "./dist/react/ui/components/marketplace-logos/index.d.ts",
 			"default": "./dist/react/ui/components/marketplace-logos/index.js"
 		},
+		"./react-day-picker/style.css": {
+			"default": "./dist/react-day-picker.css"
+		},
 		"./styles/index.css": {
 			"default": "./dist/index.css"
 		},

--- a/sdk/tsdown.config.ts
+++ b/sdk/tsdown.config.ts
@@ -17,6 +17,7 @@ export default defineConfig([
 		plugins: [preserveDirectives()],
 		onSuccess: () => {
 			execAsync('pnpm tailwindcss -i ./src/index.css -o ./dist/index.css');
+			execAsync('cp ./node_modules/react-day-picker/src/style.css ./dist/react-day-picker.css');
 		},
 		loader: {
 			'.png': 'dataurl',


### PR DESCRIPTION
This patch copies react-day-picker's css file to the dist folder, and adds an export path to the package.json, which allows Vite to successfully import the file during it's SSR build process.