### PR TITLE
Fix Safari detection compatibility with Server-Side Rendering

### DIFF
--- a/sdk/src/react/ui/components/media/Media.tsx
+++ b/sdk/src/react/ui/components/media/Media.tsx
@@ -34,6 +34,7 @@ export function Media({
 	const [assetLoadFailed, setAssetLoadFailed] = useState(false);
 	const [assetLoading, setAssetLoading] = useState(true);
 	const [currentAssetIndex, setCurrentAssetIndex] = useState(0);
+	const [isSafari, setIsSafari] = useState(false);
 	const [contentType, setContentType] = useState<ContentTypeState>({
 		type: null,
 		loading: true,
@@ -41,7 +42,10 @@ export function Media({
 	});
 
 	const videoRef = useRef<HTMLVideoElement>(null);
-	const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+	useEffect(() => {
+		setIsSafari(/^((?!chrome|android).)*safari/i.test(navigator.userAgent));
+	}, []);
 
 	const validAssets = assets.filter((asset): asset is string => !!asset);
 	const assetUrl = validAssets[currentAssetIndex];


### PR DESCRIPTION
## Problem
The Media component was performing Safari browser detection using `navigator.userAgent` 
during component initialization, which caused errors during Next.js server-side rendering 
since `navigator` is not available in the server environment.

![Screenshot 2025-06-09 at 16 20 39](https://github.com/user-attachments/assets/eae30127-0c3d-478a-b2ed-b7cb05b07796)


## Solution
- Added `isSafari` state initialized to `false`
- Moved Safari detection logic into a `useEffect` hook
- Ensures browser detection only runs after component mount on the client side