### PR TITLE
Enhance Media component to conditionally handle asset loading

### DIFF
--- a/playgrounds/react-vite/src/tabs/Collections.tsx
+++ b/playgrounds/react-vite/src/tabs/Collections.tsx
@@ -48,6 +48,7 @@ function CollectionCard({
 			<Media
 				assets={[collection.extensions.ogImage]}
 				className="h-full w-full object-cover transition-transform duration-500 ease-in-out group-hover:scale-110"
+				shouldListenForLoad={false}
 			/>
 
 			<div className="absolute right-0 bottom-0 left-0 flex items-center bg-background-primary bg-opacity-80 p-4 backdrop-blur-sm">

--- a/sdk/.changeset/fine-groups-repeat.md
+++ b/sdk/.changeset/fine-groups-repeat.md
@@ -1,0 +1,5 @@
+---
+"@0xsequence/marketplace-sdk": patch
+---
+
+Added `shouldListenForLoad` prop to the `Media` component, allowing control over whether to listen for asset load events.

--- a/sdk/src/react/ui/components/media/Media.tsx
+++ b/sdk/src/react/ui/components/media/Media.tsx
@@ -30,9 +30,10 @@ export function Media({
 	className,
 	isLoading,
 	fallbackContent,
+	shouldListenForLoad = true,
 }: MediaProps) {
 	const [assetLoadFailed, setAssetLoadFailed] = useState(false);
-	const [assetLoading, setAssetLoading] = useState(true);
+	const [assetLoading, setAssetLoading] = useState(shouldListenForLoad);
 	const [currentAssetIndex, setCurrentAssetIndex] = useState(0);
 	const [isSafari, setIsSafari] = useState(false);
 	const [contentType, setContentType] = useState<ContentTypeState>({
@@ -153,8 +154,8 @@ export function Media({
 					allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
 					sandbox="allow-scripts"
 					style={{ border: '0px' }}
-					onError={handleAssetError}
-					onLoad={handleAssetLoad}
+					onError={shouldListenForLoad ? handleAssetError : undefined}
+					onLoad={shouldListenForLoad ? handleAssetLoad : undefined}
 				/>
 			</div>
 		);
@@ -166,8 +167,8 @@ export function Media({
 				<ModelViewer
 					src={proxiedAssetUrl}
 					posterSrc={ChessTileImage}
-					onLoad={handleAssetLoad}
-					onError={handleAssetError}
+					onLoad={shouldListenForLoad ? handleAssetLoad : undefined}
+					onError={shouldListenForLoad ? handleAssetError : undefined}
 				/>
 			</div>
 		);
@@ -197,8 +198,8 @@ export function Media({
 					playsInline
 					muted
 					controlsList="nodownload noremoteplayback nofullscreen"
-					onError={handleAssetError}
-					onLoadedMetadata={handleAssetLoad}
+					onError={shouldListenForLoad ? handleAssetError : undefined}
+					onLoadedMetadata={shouldListenForLoad ? handleAssetLoad : undefined}
 					data-testid="collectible-asset-video"
 				>
 					<source src={proxiedAssetUrl} />
@@ -224,8 +225,8 @@ export function Media({
 				src={imgSrc}
 				alt={name || 'Collectible'}
 				className={imgClassNames}
-				onError={handleAssetError}
-				onLoad={handleAssetLoad}
+				onError={shouldListenForLoad ? handleAssetError : undefined}
+				onLoad={shouldListenForLoad ? handleAssetLoad : undefined}
 			/>
 		</div>
 	);

--- a/sdk/src/react/ui/components/media/types.ts
+++ b/sdk/src/react/ui/components/media/types.ts
@@ -15,6 +15,7 @@ type MediaProps = {
 	className?: string;
 	isLoading?: boolean;
 	fallbackContent?: ReactNode;
+	shouldListenForLoad?: boolean;
 };
 
 export type { ContentType, ContentTypeState, MediaProps };


### PR DESCRIPTION
- Added `shouldListenForLoad` prop to the Media component, allowing control over whether to listen for asset load events.
- Updated internal state management to initialize loading based on the new prop.
- Modified event handlers for various asset types to conditionally attach error and load handlers based on the `shouldListenForLoad` prop.
- Updated CollectionCard to set `shouldListenForLoad` to false, preventing load event handling for the displayed media.