### PR TITLE
Remove usage of getNetwork form sequence connect

### DIFF
--- a/playgrounds/shared/src/components/collections/NetworkPill.tsx
+++ b/playgrounds/shared/src/components/collections/NetworkPill.tsx
@@ -1,5 +1,5 @@
-import { getNetwork } from '@0xsequence/connect';
 import { NetworkImage, Text } from '@0xsequence/design-system';
+import { getNetwork } from '@0xsequence/marketplace-sdk';
 
 export interface NetworkPillProps {
 	chainId: number;

--- a/playgrounds/shared/src/components/pages/InventoryPageController.tsx
+++ b/playgrounds/shared/src/components/pages/InventoryPageController.tsx
@@ -1,9 +1,9 @@
-import { getNetwork } from '@0xsequence/connect';
 import { NetworkImage, Text } from '@0xsequence/design-system';
 import {
 	type CollectibleCardAction,
 	type CollectibleOrder,
 	ContractType,
+	getNetwork,
 	type Order,
 	OrderbookKind,
 	type TokenMetadata,

--- a/sdk/src/react/_internal/api/services.ts
+++ b/sdk/src/react/_internal/api/services.ts
@@ -1,9 +1,9 @@
 import { SequenceAPIClient } from '@0xsequence/api';
 import { SequenceIndexer } from '@0xsequence/indexer';
 import { SequenceMetadata } from '@0xsequence/metadata';
-import { networks, stringTemplate } from '@0xsequence/network';
+import { stringTemplate } from '@0xsequence/network';
 import type { ApiConfig, Env, SdkConfig } from '../../../types/sdk-config';
-import { MissingConfigError } from '../../../utils/_internal/error/transaction';
+import { getNetwork } from '../../../utils/network';
 import { BuilderAPI } from './builder-api';
 import { SequenceMarketplace } from './marketplace-api';
 
@@ -21,18 +21,6 @@ const SERVICES = {
 };
 
 type ChainNameOrId = string | number;
-
-const getNetwork = (nameOrId: ChainNameOrId) => {
-	for (const network of Object.values(networks)) {
-		if (
-			network.name === String(nameOrId).toLowerCase() ||
-			network.chainId === Number(nameOrId)
-		) {
-			return network;
-		}
-	}
-	throw new MissingConfigError(`Network configuration for chain ${nameOrId}`);
-};
 
 const metadataURL = (env: Env = 'production') => {
 	const prefix = getPrefix(env);

--- a/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/MakeOfferModal/Modal.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { getNetwork } from '@0xsequence/connect';
 import { NetworkType } from '@0xsequence/network';
 import { observer, Show, use$ } from '@legendapp/state/react';
 import { useState } from 'react';
 import { parseUnits } from 'viem';
 import type { FeeOption } from '../../../../types/waas-types';
 import { dateToUnixTime } from '../../../../utils/date';
+import { getNetwork } from '../../../../utils/network';
 import { ContractType } from '../../../_internal';
 import { useWallet } from '../../../_internal/wallet/useWallet';
 import {

--- a/sdk/src/react/ui/modals/SellModal/Modal.tsx
+++ b/sdk/src/react/ui/modals/SellModal/Modal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { getNetwork } from '@0xsequence/connect';
 import { NetworkType } from '@0xsequence/network';
 import { observer, Show } from '@legendapp/state/react';
 import { type Address, parseUnits } from 'viem';
 import type { Price } from '../../../../types';
 import type { FeeOption } from '../../../../types/waas-types';
+import { getNetwork } from '../../../../utils/network';
 import type { MarketplaceKind } from '../../../_internal/api/marketplace.gen';
 import { useWallet } from '../../../_internal/wallet/useWallet';
 import { useCollection, useCurrency } from '../../../hooks';

--- a/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/_components/TransferButton.tsx
+++ b/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/_components/TransferButton.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { getNetwork } from '@0xsequence/connect';
 import { Button, Spinner } from '@0xsequence/design-system';
 import { NetworkType } from '@0xsequence/network';
 import { observer } from '@legendapp/state/react';
+import { getNetwork } from '../../../../../../../utils/network';
 import { useWallet } from '../../../../../../_internal/wallet/useWallet';
 import { transferModal$ } from '../../../_store';
 

--- a/sdk/src/utils/network.ts
+++ b/sdk/src/utils/network.ts
@@ -1,4 +1,19 @@
 import { networks } from '@0xsequence/network';
+import { MissingConfigError } from './_internal/error/transaction';
+
+type ChainNameOrId = string | number;
+
+export const getNetwork = (nameOrId: ChainNameOrId) => {
+	for (const network of Object.values(networks)) {
+		if (
+			network.name === String(nameOrId).toLowerCase() ||
+			network.chainId === Number(nameOrId)
+		) {
+			return network;
+		}
+	}
+	throw new MissingConfigError(`Network configuration for chain ${nameOrId}`);
+};
 
 export const getPresentableChainName = (chainId: number) => {
 	return networks[chainId as keyof typeof networks]?.title ?? 'Unknown Network';


### PR DESCRIPTION
We are moving towards being able to replace sequence/connect with other providers, removing usage of getNetwork from sequence/connect makes that easier