### PR TITLE
fix action button visibility for shop collectible card

### DIFF
--- a/sdk/.changeset/early-buckets-call.md
+++ b/sdk/.changeset/early-buckets-call.md
@@ -1,0 +1,5 @@
+---
+"@0xsequence/marketplace-sdk": patch
+---
+
+fix: hide buy button when ERC1155 sale item is out of stock

--- a/sdk/src/react/hooks/useList1155ShopCardData.tsx
+++ b/sdk/src/react/hooks/useList1155ShopCardData.tsx
@@ -75,6 +75,7 @@ export function useList1155ShopCardData({
 		};
 
 		const supply = saleData?.supply?.toString();
+		const unlimitedSupply = saleData?.unlimitedSupply;
 
 		return {
 			collectibleId: tokenId,
@@ -88,6 +89,7 @@ export function useList1155ShopCardData({
 			quantityInitial: supply,
 			quantityDecimals: collection?.decimals || 0,
 			quantityRemaining: supply,
+			unlimitedSupply,
 			saleStartsAt: saleData?.startDate?.toString(),
 			saleEndsAt: saleData?.endDate?.toString(),
 			marketplaceType: 'shop',

--- a/sdk/src/react/ui/components/_internals/action-button/ActionButton.tsx
+++ b/sdk/src/react/ui/components/_internals/action-button/ActionButton.tsx
@@ -32,6 +32,7 @@ type ActionButtonProps = {
 	};
 	quantityDecimals?: number;
 	quantityRemaining?: number;
+	unlimitedSupply?: boolean;
 };
 
 export function ActionButton({
@@ -50,6 +51,7 @@ export function ActionButton({
 	salePrice,
 	quantityDecimals,
 	quantityRemaining,
+	unlimitedSupply,
 }: ActionButtonProps) {
 	const { shouldShowAction, isOwnerAction } = useActionButtonLogic({
 		tokenId,
@@ -87,6 +89,7 @@ export function ActionButton({
 					chainId,
 					quantityDecimals,
 					quantityRemaining,
+					unlimitedSupply,
 				}
 			: {
 					marketplaceType: 'market' as const,

--- a/sdk/src/react/ui/components/_internals/action-button/components/NonOwnerActions.tsx
+++ b/sdk/src/react/ui/components/_internals/action-button/components/NonOwnerActions.tsx
@@ -15,6 +15,7 @@ type NonOwnerActionsBaseProps = {
 	chainId: number;
 	quantityDecimals?: number;
 	quantityRemaining?: number;
+	unlimitedSupply?: boolean;
 };
 
 type ShopNonOwnerActionsProps = NonOwnerActionsBaseProps & {
@@ -48,6 +49,7 @@ export function NonOwnerActions(props: NonOwnerActionsProps) {
 		chainId,
 		quantityDecimals,
 		quantityRemaining,
+		unlimitedSupply,
 		marketplaceType,
 	} = props;
 
@@ -80,6 +82,7 @@ export function NonOwnerActions(props: NonOwnerActionsProps) {
 						},
 						quantityDecimals: quantityDecimals ?? 0,
 						quantityRemaining: quantityRemaining ?? 0,
+						unlimitedSupply,
 					})
 				}
 				icon={SvgCartIcon}

--- a/sdk/src/react/ui/components/marketplace-collectible-card/Footer.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/Footer.tsx
@@ -58,6 +58,7 @@ type FooterProps = {
 	balance?: string;
 	quantityInitial: string | undefined;
 	quantityRemaining: string | undefined;
+	unlimitedSupply?: boolean;
 	marketplaceType: MarketplaceType;
 	salePriceAmount?: string;
 	salePriceCurrency?: Currency;
@@ -74,6 +75,7 @@ export const Footer = ({
 	balance,
 	quantityInitial,
 	quantityRemaining,
+	unlimitedSupply,
 	marketplaceType,
 	salePriceAmount,
 	salePriceCurrency,
@@ -166,9 +168,9 @@ export const Footer = ({
 
 			{isShop && (
 				<SaleDetailsPill
-					quantityInitial={quantityInitial}
 					quantityRemaining={quantityRemaining}
 					collectionType={type as ContractType}
+					unlimitedSupply={unlimitedSupply}
 				/>
 			)}
 
@@ -209,18 +211,18 @@ const TokenTypeBalancePill = ({
 };
 
 const SaleDetailsPill = ({
-	quantityInitial,
 	quantityRemaining,
 	collectionType,
+	unlimitedSupply,
 }: {
-	quantityInitial: string | undefined;
 	quantityRemaining: string | undefined;
 	collectionType: ContractType;
+	unlimitedSupply?: boolean;
 }) => {
 	const supplyText = getSupplyStatusText({
-		quantityInitial,
 		quantityRemaining,
 		collectionType,
+		unlimitedSupply,
 	});
 
 	return (

--- a/sdk/src/react/ui/components/marketplace-collectible-card/components/ActionButtonWrapper.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/components/ActionButtonWrapper.tsx
@@ -30,6 +30,7 @@ interface ActionButtonWrapperProps {
 	};
 	quantityDecimals?: number;
 	quantityRemaining?: number;
+	unlimitedSupply?: boolean;
 }
 
 export function ActionButtonWrapper({
@@ -49,6 +50,7 @@ export function ActionButtonWrapper({
 	salePrice,
 	quantityDecimals,
 	quantityRemaining,
+	unlimitedSupply,
 }: ActionButtonWrapperProps) {
 	if (!show) return null;
 
@@ -70,6 +72,7 @@ export function ActionButtonWrapper({
 				salePrice={salePrice}
 				quantityDecimals={quantityDecimals}
 				quantityRemaining={quantityRemaining}
+				unlimitedSupply={unlimitedSupply}
 			/>
 		</div>
 	);

--- a/sdk/src/react/ui/components/marketplace-collectible-card/types.ts
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/types.ts
@@ -34,6 +34,7 @@ type ShopCardSpecificProps = {
 	quantityDecimals: number | undefined;
 	quantityInitial: string | undefined;
 	quantityRemaining: string | undefined;
+	unlimitedSupply?: boolean; // it's useful for 1155 tokens
 };
 
 // Properties specific to marketplace and inventory cards

--- a/sdk/src/react/ui/components/marketplace-collectible-card/utils/supplyStatus.ts
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/utils/supplyStatus.ts
@@ -1,18 +1,15 @@
 import { ContractType } from '../../../../_internal';
 
 export const getSupplyStatusText = ({
-	quantityInitial,
 	quantityRemaining,
 	collectionType,
+	unlimitedSupply,
 }: {
-	quantityInitial: string | undefined;
 	quantityRemaining: string | undefined;
 	collectionType: ContractType;
+	unlimitedSupply?: boolean;
 }): string => {
-	const hasUnlimitedSupplyCap =
-		quantityInitial === Number.POSITIVE_INFINITY.toString();
-
-	if (hasUnlimitedSupplyCap) {
+	if (unlimitedSupply) {
 		return 'Unlimited Supply';
 	}
 
@@ -25,7 +22,7 @@ export const getSupplyStatusText = ({
 
 	if (
 		collectionType === ContractType.ERC1155 &&
-		!hasUnlimitedSupplyCap &&
+		!unlimitedSupply &&
 		quantityRemaining === '0'
 	) {
 		return 'Out of stock';

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -99,6 +99,7 @@ export function ShopCard({
 						? Number(quantityRemaining)
 						: undefined
 				}
+				unlimitedSupply={unlimitedSupply}
 			/>
 		</BaseCard>
 	);

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -47,7 +47,8 @@ export function ShopCard({
 	const showActionButton =
 		salesContractAddress &&
 		collectionType === ContractType.ERC1155 &&
-		quantityRemaining !== undefined;
+		quantityRemaining !== undefined &&
+		Number(quantityRemaining) > 0;
 
 	const action = CollectibleCardAction.BUY;
 

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -22,6 +22,7 @@ export function ShopCard({
 	quantityDecimals,
 	quantityInitial,
 	quantityRemaining,
+	unlimitedSupply,
 }: ShopCollectibleCardProps) {
 	const { data: saleCurrency, isLoading: saleCurrencyLoading } = useCurrency({
 		chainId,
@@ -47,8 +48,8 @@ export function ShopCard({
 	const showActionButton =
 		salesContractAddress &&
 		collectionType === ContractType.ERC1155 &&
-		quantityRemaining !== undefined &&
-		Number(quantityRemaining) > 0;
+		(unlimitedSupply ||
+			(quantityRemaining !== undefined && Number(quantityRemaining) > 0));
 
 	const action = CollectibleCardAction.BUY;
 
@@ -76,6 +77,7 @@ export function ShopCard({
 				decimals={tokenMetadata.decimals}
 				quantityInitial={quantityInitial}
 				quantityRemaining={quantityRemaining}
+				unlimitedSupply={unlimitedSupply}
 				marketplaceType={marketplaceType}
 				salePriceAmount={salePrice?.amount}
 				salePriceCurrency={saleCurrency}

--- a/sdk/src/react/ui/modals/BuyModal/components/ERC1155QuantityModal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/components/ERC1155QuantityModal.tsx
@@ -3,6 +3,7 @@
 import { Text, TokenImage } from '@0xsequence/design-system';
 import { useState } from 'react';
 import type { Address } from 'viem';
+import { maxUint256 } from 'viem';
 import { DEFAULT_MARKETPLACE_FEE_PERCENTAGE } from '../../../../../consts';
 import type { MarketplaceType } from '../../../../../types';
 import { formatPriceWithFee } from '../../../../../utils/price';
@@ -12,8 +13,7 @@ import { ActionModal } from '../../_internal/components/actionModal';
 import QuantityInput from '../../_internal/components/quantityInput';
 import { buyModalStore, useIsOpen } from '../store';
 
-const INFINITY_STRING =
-	'9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999';
+const INFINITY_STRING = maxUint256.toString();
 
 type ERC1155QuantityModalProps = {
 	order?: Order;

--- a/sdk/src/react/ui/modals/BuyModal/components/ERC1155QuantityModal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/components/ERC1155QuantityModal.tsx
@@ -12,11 +12,15 @@ import { ActionModal } from '../../_internal/components/actionModal';
 import QuantityInput from '../../_internal/components/quantityInput';
 import { buyModalStore, useIsOpen } from '../store';
 
+const INFINITY_STRING =
+	'9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999';
+
 type ERC1155QuantityModalProps = {
 	order?: Order;
 	marketplaceType: MarketplaceType;
 	quantityDecimals: number;
 	quantityRemaining: string;
+	unlimitedSupply?: boolean;
 	salePrice?: {
 		amount: string;
 		currencyAddress: Address;
@@ -28,6 +32,7 @@ export const ERC1155QuantityModal = ({
 	order,
 	quantityDecimals,
 	quantityRemaining,
+	unlimitedSupply,
 	salePrice,
 	chainId,
 	marketplaceType,
@@ -36,6 +41,8 @@ export const ERC1155QuantityModal = ({
 
 	const [localQuantity, setLocalQuantity] = useState('1');
 	const [invalidQuantity, setInvalidQuantity] = useState(false);
+
+	const maxQuantity = unlimitedSupply ? INFINITY_STRING : quantityRemaining;
 
 	return (
 		<ActionModal
@@ -64,7 +71,7 @@ export const ERC1155QuantityModal = ({
 					onQuantityChange={setLocalQuantity}
 					onInvalidQuantityChange={setInvalidQuantity}
 					decimals={quantityDecimals}
-					maxQuantity={quantityRemaining}
+					maxQuantity={maxQuantity}
 				/>
 
 				<TotalPrice

--- a/sdk/src/react/ui/modals/BuyModal/components/ERC1155ShopModal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/components/ERC1155ShopModal.tsx
@@ -37,6 +37,8 @@ export const ERC1155ShopModal = ({
 		isShop && modalProps.quantityRemaining
 			? modalProps.quantityRemaining.toString()
 			: '0';
+	const unlimitedSupply =
+		isShop && modalProps.unlimitedSupply ? modalProps.unlimitedSupply : false;
 
 	if (!quantity) {
 		return (
@@ -49,6 +51,7 @@ export const ERC1155ShopModal = ({
 				marketplaceType="shop"
 				quantityDecimals={quantityDecimals}
 				quantityRemaining={quantityRemaining}
+				unlimitedSupply={unlimitedSupply}
 				chainId={chainId}
 			/>
 		);

--- a/sdk/src/react/ui/modals/BuyModal/store.ts
+++ b/sdk/src/react/ui/modals/BuyModal/store.ts
@@ -47,6 +47,7 @@ export type ShopBuyModalProps = BuyModalBaseProps & {
 		amount: string;
 		currencyAddress: Address;
 	};
+	unlimitedSupply?: boolean;
 };
 
 // Marketplace type modal props


### PR DESCRIPTION
Show "buy now" action button only when quantityRemaining is greater than zero.
Fixes [this](https://github.com/0xsequence/issue-tracker/issues/5351)

https://github.com/user-attachments/assets/6e12448d-93cd-463d-98cf-a7d500a0a04b

