### PR TITLE
useListMarketCardData: to make orderbookKind optional

### DIFF
--- a/sdk/src/react/hooks/useListMarketCardData.tsx
+++ b/sdk/src/react/hooks/useListMarketCardData.tsx
@@ -19,7 +19,8 @@ import { useListCollectibles } from './useListCollectibles';
 interface UseListMarketCardDataProps {
 	collectionAddress: Address;
 	chainId: number;
-	orderbookKind: OrderbookKind;
+	// orderbookKind is optional — used to override marketplace config for internal tests
+	orderbookKind?: OrderbookKind;
 	collectionType: ContractType;
 	filterOptions?: PropertyFilter[];
 	searchText?: string;


### PR DESCRIPTION
It's being used for just internal testing purposes, no need to override the `orderbookKind` from `marketplaceConfig` in practice.