### PR TITLE
fix(BuyModal): prevent unwanted analytics requests on collectible listings

### DIFF
--- a/sdk/src/react/ui/modals/BuyModal/__tests__/BuyModalRouter.test.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/__tests__/BuyModalRouter.test.tsx
@@ -7,7 +7,7 @@ import {
 	OrderSide,
 	OrderStatus,
 } from '../../../../_internal';
-import type { DatabeatAnalytics } from '../../../../_internal/databeat';
+
 import { BuyModalRouter } from '../components/BuyModalRouter';
 import * as useLoadDataModule from '../hooks/useLoadData';
 import { buyModalStore } from '../store';
@@ -190,10 +190,6 @@ const mockShopData = {
 	checkoutOptions: undefined,
 };
 
-const mockAnalyticsFn = {
-	trackBuyModalOpened: vi.fn(),
-} as unknown as DatabeatAnalytics;
-
 describe('BuyModalRouter', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -216,7 +212,6 @@ describe('BuyModalRouter', () => {
 					orderId: '1',
 					marketplaceType: 'market',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock useLoadData to return complete data for ERC721 market flow
@@ -252,7 +247,6 @@ describe('BuyModalRouter', () => {
 					orderId: '1',
 					marketplaceType: 'market',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock useLoadData to return complete data for ERC1155 market flow
@@ -286,7 +280,6 @@ describe('BuyModalRouter', () => {
 					marketplace: MarketplaceKind.sequence_marketplace_v2,
 					orderId: '1',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock incomplete data
@@ -326,7 +319,6 @@ describe('BuyModalRouter', () => {
 					},
 					marketplaceType: 'shop',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock useLoadData to return complete data for ERC721 shop flow
@@ -367,7 +359,6 @@ describe('BuyModalRouter', () => {
 					},
 					marketplaceType: 'shop',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock useLoadData to return complete data for ERC1155 shop flow
@@ -407,7 +398,6 @@ describe('BuyModalRouter', () => {
 					},
 					marketplaceType: 'shop',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock incomplete shop data
@@ -440,7 +430,6 @@ describe('BuyModalRouter', () => {
 					marketplace: MarketplaceKind.sequence_marketplace_v2,
 					orderId: '1',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock error state
@@ -471,7 +460,6 @@ describe('BuyModalRouter', () => {
 					marketplace: MarketplaceKind.sequence_marketplace_v2,
 					orderId: '1',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock loading state
@@ -508,7 +496,6 @@ describe('BuyModalRouter', () => {
 					},
 					marketplaceType: 'shop',
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock unsupported collection type
@@ -545,7 +532,6 @@ describe('BuyModalRouter', () => {
 					orderId: '1',
 					// marketplaceType not specified - should default to MARKET
 				},
-				analyticsFn: mockAnalyticsFn,
 			});
 
 			// Mock useLoadData to return complete data for ERC721 market flow

--- a/sdk/src/react/ui/modals/BuyModal/__tests__/ERC1155ShopModal.test.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/__tests__/ERC1155ShopModal.test.tsx
@@ -4,17 +4,13 @@ import type { Address } from 'viem';
 import type { Mock, MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TransactionCrypto } from '../../../../_internal';
-import type { DatabeatAnalytics } from '../../../../_internal/databeat';
+
 import { ERC1155ShopModal } from '../components/ERC1155ShopModal';
 import * as useERC1155CheckoutModule from '../hooks/useERC1155Checkout';
 import { buyModalStore } from '../store';
 
 // Mock the checkout hook
 vi.mock('../hooks/useERC1155Checkout');
-
-const mockAnalyticsFn = {
-	trackBuyModalOpened: vi.fn(),
-} as unknown as DatabeatAnalytics;
 
 const mockCollection = {
 	address: '0x123' as Address,
@@ -82,7 +78,6 @@ describe('ERC1155ShopModal', () => {
 				},
 				marketplaceType: 'shop',
 			},
-			analyticsFn: mockAnalyticsFn,
 		});
 	});
 

--- a/sdk/src/react/ui/modals/BuyModal/__tests__/Modal1155.test.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/__tests__/Modal1155.test.tsx
@@ -5,16 +5,11 @@ import {
 	screen,
 	waitForElementToBeRemoved,
 } from '@test';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Order } from '../../../../_internal';
 import { MarketplaceKind, OrderSide, OrderStatus } from '../../../../_internal';
-import type { DatabeatAnalytics } from '../../../../_internal/databeat';
 import { ERC1155QuantityModal } from '../components/ERC1155QuantityModal';
 import { buyModalStore } from '../store';
-
-const analyticsFn = {
-	trackBuyModalOpened: vi.fn(),
-} as unknown as DatabeatAnalytics;
 
 const testOrder: Order = {
 	chainId: 1,
@@ -62,7 +57,6 @@ describe('ERC1155QuantityModal', () => {
 				marketplace: MarketplaceKind.sequence_marketplace_v2,
 				marketplaceType: 'market',
 			},
-			analyticsFn,
 		});
 	});
 

--- a/sdk/src/react/ui/modals/BuyModal/__tests__/store.test.ts
+++ b/sdk/src/react/ui/modals/BuyModal/__tests__/store.test.ts
@@ -1,11 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { MarketplaceKind } from '../../../../_internal';
-import type { DatabeatAnalytics } from '../../../../_internal/databeat';
 import { buyModalStore, type MarketplaceBuyModalProps } from '../store';
-
-const analyticsFn = {
-	trackBuyModalOpened: vi.fn(),
-} as unknown as DatabeatAnalytics;
 
 describe('BuyModal Store', () => {
 	beforeEach(() => {
@@ -34,7 +29,6 @@ describe('BuyModal Store', () => {
 			props: mockProps,
 			onSuccess: () => {},
 			onError: () => {},
-			analyticsFn,
 		});
 
 		const state = buyModalStore.getSnapshot();
@@ -57,7 +51,6 @@ describe('BuyModal Store', () => {
 			props: mockProps,
 			onSuccess: () => {},
 			onError: () => {},
-			analyticsFn,
 		});
 
 		const openState = buyModalStore.getSnapshot();
@@ -82,7 +75,6 @@ describe('BuyModal Store', () => {
 		buyModalStore.send({
 			type: 'open',
 			props: mockProps,
-			analyticsFn,
 		});
 
 		const state1 = buyModalStore.getSnapshot();

--- a/sdk/src/react/ui/modals/BuyModal/components/BuyModalRouter.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/components/BuyModalRouter.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useAnalytics } from '../../../../_internal/databeat';
+import { flattenAnalyticsArgs } from '../../../../_internal/databeat/utils';
 import { ErrorModal } from '../../_internal/components/actionModal/ErrorModal';
 import { LoadingModal } from '../../_internal/components/actionModal/LoadingModal';
 import { useLoadData } from '../hooks/useLoadData';
 import {
 	buyModalStore,
 	isShopProps,
+	useBuyAnalyticsId,
 	useBuyModalProps,
 	useOnError,
 } from '../store';
@@ -19,6 +23,8 @@ export const BuyModalRouter = () => {
 	const chainId = modalProps.chainId;
 	const isShop = isShopProps(modalProps);
 	const onError = useOnError();
+	const buyAnalyticsId = useBuyAnalyticsId();
+	const analytics = useAnalytics();
 	const {
 		collection,
 		collectable,
@@ -30,6 +36,26 @@ export const BuyModalRouter = () => {
 		shopData,
 		isError,
 	} = useLoadData();
+
+	// Track analytics when modal opens (only once per modal open)
+	useEffect(() => {
+		if (buyAnalyticsId) {
+			const { analyticsProps, analyticsNums } =
+				flattenAnalyticsArgs(modalProps);
+
+			analytics.trackBuyModalOpened({
+				props: {
+					buyAnalyticsId,
+					collectionAddress: modalProps.collectionAddress,
+					...analyticsProps,
+				},
+				nums: {
+					chainId: modalProps.chainId,
+					...analyticsNums,
+				},
+			});
+		}
+	}, [buyAnalyticsId, analytics, modalProps]);
 
 	if (isError) {
 		return (

--- a/sdk/src/react/ui/modals/BuyModal/index.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/index.tsx
@@ -1,17 +1,13 @@
-import { useAnalytics } from '../../../_internal/databeat';
 import type { ModalCallbacks } from '../_internal/types';
 import { type BuyModalProps, buyModalStore } from './store';
 
 export const useBuyModal = (callbacks?: ModalCallbacks) => {
-	const analyticsFn = useAnalytics();
-
 	return {
 		show: (args: BuyModalProps) =>
 			buyModalStore.send({
 				type: 'open',
 				props: args,
 				...callbacks,
-				analyticsFn,
 			}),
 		close: () => buyModalStore.send({ type: 'close' }),
 	};

--- a/sdk/src/react/ui/modals/BuyModal/store.ts
+++ b/sdk/src/react/ui/modals/BuyModal/store.ts
@@ -7,8 +7,6 @@ import type {
 	MarketplaceKind,
 	Step,
 } from '../../../_internal';
-import type { useAnalytics } from '../../../_internal/databeat';
-import { flattenAnalyticsArgs } from '../../../_internal/databeat/utils';
 
 export type CheckoutOptionsSalesContractProps = {
 	chainId: number;
@@ -107,7 +105,6 @@ export const buyModalStore = createStore({
 				props: BuyModalProps;
 				onError?: onErrorCallback;
 				onSuccess?: onSuccessCallback;
-				analyticsFn: ReturnType<typeof useAnalytics>;
 			},
 		) => {
 			// Prevent duplicate opens
@@ -115,22 +112,6 @@ export const buyModalStore = createStore({
 				return context;
 			}
 			const buyAnalyticsId = crypto.randomUUID();
-
-			const { analyticsProps, analyticsNums } = flattenAnalyticsArgs(
-				event.props,
-			);
-
-			event.analyticsFn.trackBuyModalOpened({
-				props: {
-					buyAnalyticsId,
-					collectionAddress: event.props.collectionAddress,
-					...analyticsProps,
-				},
-				nums: {
-					chainId: event.props.chainId,
-					...analyticsNums,
-				},
-			});
 			return {
 				...context,
 				props: event.props,


### PR DESCRIPTION
The BuyModal was causing unwanted "Tick" requests for all listed collectibles due to `useAnalytics()` being called at the hook level in `useBuyModal()`. This meant that every collectible card render would create a new analytics instance, leading to unnecessary network requests.

- **Moved analytics tracking** from hook level to component level (`BuyModalRouter`)
