### PR TITLE
Fix avoid auto fee selection

### DIFF
--- a/sdk/src/react/hooks/transactions/useCancelOrder.tsx
+++ b/sdk/src/react/hooks/transactions/useCancelOrder.tsx
@@ -54,7 +54,7 @@ export const useCancelOrder = ({
 					options: undefined,
 					chainId,
 				},
-		enabled: !!pendingFeeOptionConfirmation,
+		enabled: !!pendingFeeOptionConfirmation && !!cancellingOrderId,
 	});
 
 	useEffect(() => {

--- a/sdk/src/react/ui/modals/_internal/components/selectWaasFeeOptions/index.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/selectWaasFeeOptions/index.tsx
@@ -67,7 +67,7 @@ const SelectWaasFeeOptions = ({
 			{(feeOptionsConfirmed || pendingFeeOptionConfirmation) && (
 				<div
 					className={cn(
-						'[&>label>button>span]:overflow-hidden [&>label>button]:w-full [&>label>button]:text-xs [&>label]:flex [&>label]:w-full',
+						'[&>label>button>span]:overflow-hidden [&>label>button]:w-full [&>label>button]:text-xs [&>label>div]:w-full [&>label]:flex [&>label]:w-full',
 						feeOptionsConfirmed && 'pointer-events-none opacity-70',
 					)}
 				>

--- a/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsSelect/WaasFeeOptionsSelect.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/waasFeeOptionsSelect/WaasFeeOptionsSelect.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Image, Select, Text } from '@0xsequence/design-system';
+import { Image, Select, Text, Tooltip } from '@0xsequence/design-system';
 import { useEffect } from 'react';
 import { formatUnits, zeroAddress } from 'viem';
 import type { FeeOption } from '../../../../../../types/waas-types';
@@ -63,6 +63,23 @@ function FeeOptionSelectItem({
 	value: string;
 	option: FeeOption;
 }) {
+	const formattedFee = formatUnits(
+		BigInt(option.value),
+		option.token.decimals || 0,
+	);
+	const isTruncated = formattedFee.length > 11;
+	const truncatedFee = isTruncated
+		? `${formattedFee.slice(0, 11)}...`
+		: formattedFee;
+
+	const feeDisplay = isTruncated ? (
+		<Tooltip message={formattedFee}>
+			<Text className="font-body text-sm">{truncatedFee}</Text>
+		</Tooltip>
+	) : (
+		<Text className="font-body text-sm">{truncatedFee}</Text>
+	);
+
 	return {
 		value,
 		content: (
@@ -90,9 +107,7 @@ function FeeOptionSelectItem({
 					</Text>
 				</div>
 
-				<Text className="font-body text-sm">
-					{formatUnits(BigInt(option.value), option.token.decimals || 0)}
-				</Text>
+				{feeDisplay}
 			</div>
 		),
 	} as SelectItem;


### PR DESCRIPTION
While trying to sell an item with a WAAS embedded wallet connected, the modal used to automatically select the fees. However, we expect this behavior to be limited only to the ‘cancel’ action. Therefore, I updated the cancel hook. Now, automatic fee selection will no longer occur unless an orderId is provided.