### PR TITLE
Improve WaaS transfer loading states and UX

### DIFF
--- a/sdk/.changeset/tender-dancers-beg.md
+++ b/sdk/.changeset/tender-dancers-beg.md
@@ -1,0 +1,9 @@
+---
+"@0xsequence/marketplace-sdk": patch
+---
+
+feat(transfer): improve WaaS transfer UX with better loading states
+
+- Enhance TransferButton to show more accurate loading states for WaaS transfers.
+- Skip FollowWalletInstructions view for WaaS wallets since they don't need UI interaction
+

--- a/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/_components/TransferButton.tsx
+++ b/sdk/src/react/ui/modals/TransferModal/_views/enterWalletAddress/_components/TransferButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useWaasFeeOptions } from '@0xsequence/connect';
 import { Button, Spinner } from '@0xsequence/design-system';
 import { useWallet } from '../../../../../../_internal/wallet/useWallet';
 import { useModalState } from '../../../store';
@@ -14,22 +15,40 @@ const TransferButton = ({
 	const { wallet } = useWallet();
 	const isWaaS = wallet?.isWaaS;
 	const { transferIsProcessing } = useModalState();
+	const [pendingFeeOptionConfirmation] = useWaasFeeOptions();
 
-	const label = transferIsProcessing ? (
-		isWaaS ? (
-			<div className="flex items-center justify-center gap-2">
-				<Spinner size="sm" className="text-white" />
-				<span>Loading fee options</span>
-			</div>
-		) : (
+	const getLabel = () => {
+		if (!transferIsProcessing) return 'Transfer';
+
+		if (isWaaS) {
+			// If there are no fee options (sponsored tx) or fee options are confirmed
+			if (
+				!pendingFeeOptionConfirmation ||
+				pendingFeeOptionConfirmation.options.length === 0
+			) {
+				return (
+					<div className="flex items-center justify-center gap-2">
+						<Spinner size="sm" className="text-white" />
+						<span>Sending transaction</span>
+					</div>
+				);
+			}
+
+			return (
+				<div className="flex items-center justify-center gap-2">
+					<Spinner size="sm" className="text-white" />
+					<span>Loading fee options</span>
+				</div>
+			);
+		}
+
+		return (
 			<div className="flex items-center justify-center gap-2">
 				<Spinner size="sm" className="text-white" />
 				<span>Transferring</span>
 			</div>
-		)
-	) : (
-		'Transfer'
-	);
+		);
+	};
 
 	return (
 		<Button
@@ -37,7 +56,7 @@ const TransferButton = ({
 			onClick={onClick}
 			disabled={!!isDisabled}
 			title="Transfer"
-			label={label}
+			label={getLabel()}
 			variant="primary"
 			shape="square"
 			size="sm"

--- a/sdk/src/react/ui/modals/TransferModal/index.tsx
+++ b/sdk/src/react/ui/modals/TransferModal/index.tsx
@@ -66,11 +66,16 @@ export const useTransferModal = () => {
 
 const TransactionModalView = () => {
 	const view = useView();
+	const { wallet } = useWallet();
+	const isWaaS = wallet?.isWaaS;
 
 	switch (view) {
 		case 'enterReceiverAddress':
 			return <EnterWalletAddressView />;
 		case 'followWalletInstructions':
+			if (isWaaS) {
+				return <EnterWalletAddressView />;
+			}
 			return <FollowWalletInstructionsView />;
 		default:
 			return null;


### PR DESCRIPTION
https://github.com/0xsequence/issue-tracker/issues/5475

This PR improves the user experience for WaaS transfers by:

- Showing more accurate button states during transfer:
  - "Loading fee options" → "Sending transaction" for sponsored transfers
  - "Loading fee options" → Fee selection → "Sending transaction" for regular transfers
- Skipping wallet instruction view for WaaS since it's handled in the background