### PR TITLE
Make marketplace config query persistent and prevent unnecessary invalidation

### DIFF
--- a/sdk/.changeset/busy-mirrors-post.md
+++ b/sdk/.changeset/busy-mirrors-post.md
@@ -1,0 +1,7 @@
+---
+"@0xsequence/marketplace-sdk": patch
+---
+
+prevent marketplace config invalidation
+
+Makes marketplace config query persistent. Adds persistentQueryMeta and disables automatic refetching to ensure config stability.

--- a/sdk/src/react/_internal/query-meta.ts
+++ b/sdk/src/react/_internal/query-meta.ts
@@ -1,0 +1,3 @@
+export const persistentQueryMeta = {
+	persistent: true,
+};

--- a/sdk/src/react/hooks/util/optimisticCancelUpdates.ts
+++ b/sdk/src/react/hooks/util/optimisticCancelUpdates.ts
@@ -43,6 +43,7 @@ export const updateQueriesOnCancel = ({
 		queryClient.invalidateQueries({
 			queryKey: collectableKeys.highestOffers,
 			exact: false,
+			predicate: (query) => !query.meta?.persistent,
 		});
 	}, 2 * SECOND);
 

--- a/sdk/src/react/queries/marketplaceConfig.ts
+++ b/sdk/src/react/queries/marketplaceConfig.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../types/new-marketplace-types';
 import { configKeys, getBuilderClient } from '../_internal';
 import type { LookupMarketplaceReturn } from '../_internal/api/builder.gen';
+import { persistentQueryMeta } from '../_internal/query-meta';
 
 export const fetchMarketplaceConfig = async ({
 	config,
@@ -100,5 +101,11 @@ export const marketplaceConfigOptions = (config: SdkConfig) => {
 				config,
 				prefetchedMarketplaceSettings,
 			}),
+		gcTime: Number.POSITIVE_INFINITY,
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnMount: false,
+		refetchOnReconnect: false,
+		refetchOnWindowFocus: false,
+		meta: persistentQueryMeta,
 	});
 };

--- a/sdk/src/react/ui/modals/BuyModal/hooks/useERC1155Checkout.ts
+++ b/sdk/src/react/ui/modals/BuyModal/hooks/useERC1155Checkout.ts
@@ -65,7 +65,9 @@ export const useERC1155Checkout = ({
 		},
 		onClose: () => {
 			const queryClient = getQueryClient();
-			queryClient.invalidateQueries();
+			queryClient.invalidateQueries({
+				predicate: (query) => !query.meta?.persistent,
+			});
 			buyModalStore.send({ type: 'close' });
 		},
 		customProviderCallback,

--- a/sdk/src/react/ui/modals/BuyModal/hooks/useERC721SalePaymentParams.ts
+++ b/sdk/src/react/ui/modals/BuyModal/hooks/useERC721SalePaymentParams.ts
@@ -107,7 +107,9 @@ export const getERC721SalePaymentParams = async ({
 			onError: callbacks?.onError,
 			onClose: () => {
 				const queryClient = getQueryClient();
-				queryClient.invalidateQueries();
+				queryClient.invalidateQueries({
+					predicate: (query) => !query.meta?.persistent,
+				});
 				buyModalStore.send({ type: 'close' });
 			},
 			skipNativeBalanceCheck,

--- a/sdk/src/react/ui/modals/BuyModal/hooks/usePaymentModalParams.ts
+++ b/sdk/src/react/ui/modals/BuyModal/hooks/usePaymentModalParams.ts
@@ -146,7 +146,9 @@ export const getBuyCollectableParams = async ({
 		onError: callbacks?.onError,
 		onClose: () => {
 			const queryClient = getQueryClient();
-			queryClient.invalidateQueries();
+			queryClient.invalidateQueries({
+				predicate: (query) => !query.meta?.persistent,
+			});
 			buyModalStore.send({ type: 'close' });
 		},
 		skipNativeBalanceCheck,

--- a/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/index.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/transactionStatusModal/index.tsx
@@ -38,7 +38,9 @@ const invalidateQueries = async (queriesToInvalidate?: QueryKey[]) => {
 	const queryClient = getQueryClient();
 	if (!queriesToInvalidate) {
 		// Invalidate everything by default
-		queryClient.invalidateQueries();
+		queryClient.invalidateQueries({
+			predicate: (query) => !query.meta?.persistent,
+		});
 		return;
 	}
 	for (const queryKey of queriesToInvalidate) {


### PR DESCRIPTION
This PR modifies the marketplace config query to prevent unnecessary invalidation and refetching.

1. Added `persistentQueryMeta` to the marketplace config query options to prevent it from being invalidated by default query invalidation calls
2. Set `staleTime` and `gcTime` to `Number.POSITIVE_INFINITY` to ensure the data remains fresh and is never garbage collected
3. Disabled automatic refetching triggers:
   - `refetchOnMount: false`
   - `refetchOnReconnect: false`
   - `refetchOnWindowFocus: false`
