### PR TITLE
Add `useSearchTokenMetadata` hook

### DIFF
--- a/sdk/.changeset/ninety-houses-sit.md
+++ b/sdk/.changeset/ninety-houses-sit.md
@@ -1,0 +1,11 @@
+---
+"@0xsequence/marketplace-sdk": patch
+---
+
+feat(sdk): Add useSearchTokenMetadata hook
+
+Introduces a new query hook `useSearchTokenMetadata` that enables searching and filtering token metadata from the metadata API. The query:
+
+- Supports infinite pagination with configurable page size
+- Accepts chain ID, collection address, and filter parameters
+- Returns token metadata array with pagination information

--- a/sdk/src/react/_internal/api/__mocks__/metadata.msw.ts
+++ b/sdk/src/react/_internal/api/__mocks__/metadata.msw.ts
@@ -132,7 +132,13 @@ export const mockFilters = [
 	},
 ];
 
-type Endpoint = Capitalize<keyof Metadata>;
+type Endpoint =
+	| 'GetContractInfo'
+	| 'GetContractInfoBatch'
+	| 'GetTokenMetadata'
+	| 'GetTokenMetadataPropertyFilters'
+	| 'SearchTokenMetadata';
+
 type EndpointReturn<E extends Endpoint> = Awaited<
 	ReturnType<Metadata[Uncapitalize<E>]>
 >;
@@ -162,6 +168,11 @@ export const handlers = [
 
 	mockMetadataHandler('GetTokenMetadataPropertyFilters', {
 		filters: mockPropertyFilters,
+	}),
+
+	mockMetadataHandler('SearchTokenMetadata', {
+		tokenMetadata: [mockTokenMetadata],
+		page: { page: 1, pageSize: 10, more: false },
 	}),
 
 	http.post(mockMetadataEndpoint('GetContractInfoBatch'), async (request) => {

--- a/sdk/src/react/hooks/data/tokens/index.ts
+++ b/sdk/src/react/hooks/data/tokens/index.ts
@@ -1,4 +1,5 @@
 export * from './useGetTokenRanges';
 export * from './useListBalances';
 export * from './useListTokenMetadata';
+export * from './useSearchTokenMetadata';
 export * from './useTokenSupplies';

--- a/sdk/src/react/hooks/data/tokens/index.ts
+++ b/sdk/src/react/hooks/data/tokens/index.ts
@@ -1,5 +1,6 @@
 export * from './useGetTokenRanges';
 export * from './useListBalances';
 export * from './useListTokenMetadata';
+export * from './useSearchMintedTokenMetadata';
 export * from './useSearchTokenMetadata';
 export * from './useTokenSupplies';

--- a/sdk/src/react/hooks/data/tokens/useSearchMintedTokenMetadata.tsx
+++ b/sdk/src/react/hooks/data/tokens/useSearchMintedTokenMetadata.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { Optional } from '../../../_internal';
+import {
+	type SearchTokenMetadataQueryOptions,
+	searchTokenMetadataQueryOptions,
+} from '../../../queries/searchTokenMetadata';
+import { useConfig } from '../../config/useConfig';
+import { useTokenSupplies } from './useTokenSupplies';
+
+export type UseSearchMintedTokenMetadataParams = Optional<
+	SearchTokenMetadataQueryOptions,
+	'config'
+>;
+
+/**
+ * Hook to search only minted token metadata using filters with infinite pagination support
+ *
+ * Searches for minted tokens in a collection based on text and property filters.
+ * This hook combines useSearchTokenMetadata with useTokenSupplies to ensure only
+ * minted tokens are returned. Unminted tokens are filtered out by checking their supply.
+ *
+ * @param params - Configuration parameters
+ * @param params.chainId - The chain ID (must be number, e.g., 1 for Ethereum, 137 for Polygon)
+ * @param params.collectionAddress - The collection contract address
+ * @param params.filter - Filter criteria for the search
+ * @param params.filter.text - Optional text search query
+ * @param params.filter.properties - Optional array of property filters
+ * @param params.page - Optional pagination parameters
+ * @param params.query - Optional React Query configuration
+ *
+ * @returns Infinite query result containing matching minted token metadata with pagination support
+ *
+ * @example
+ * Basic text search with pagination:
+ * ```typescript
+ * const { data, isLoading, fetchNextPage, hasNextPage } = useSearchMintedTokenMetadata({
+ *   chainId: 137,
+ *   collectionAddress: '0x...',
+ *   filter: {
+ *     text: 'dragon'
+ *   }
+ * })
+ * ```
+ *
+ * @example
+ * Property filters:
+ * ```typescript
+ * const { data, fetchNextPage } = useSearchMintedTokenMetadata({
+ *   chainId: 1,
+ *   collectionAddress: '0x...',
+ *   filter: {
+ *     properties: [
+ *       {
+ *         name: 'Rarity',
+ *         type: PropertyType.STRING,
+ *         values: ['Legendary', 'Epic']
+ *       },
+ *       {
+ *         name: 'Level',
+ *         type: PropertyType.INT,
+ *         min: 50,
+ *         max: 100
+ *       }
+ *     ]
+ *   }
+ * })
+ * ```
+ */
+export function useSearchMintedTokenMetadata(
+	params: UseSearchMintedTokenMetadataParams,
+) {
+	const defaultConfig = useConfig();
+	const {
+		config = defaultConfig,
+		chainId,
+		collectionAddress,
+		...rest
+	} = params;
+
+	// Get token supplies to check which tokens are minted
+	const { data: tokenSupplies } = useTokenSupplies({
+		chainId,
+		collectionAddress,
+		includeMetadata: false,
+	});
+
+	// Create a Set of minted token IDs for efficient lookup
+	const mintedTokenIds = new Set(
+		tokenSupplies?.tokenIDs
+			?.filter((token) => BigInt(token.supply) > 0n)
+			.map((token) => token.tokenID) ?? [],
+	);
+
+	const queryOptions = searchTokenMetadataQueryOptions({
+		config,
+		chainId,
+		collectionAddress,
+		...rest,
+	});
+
+	const result = useInfiniteQuery({
+		...queryOptions,
+	});
+
+	return {
+		...result,
+		data: result.data
+			? {
+					tokenMetadata: result.data.pages
+						.flatMap((page) => page.tokenMetadata)
+						.filter((metadata) => mintedTokenIds.has(metadata.tokenId)),
+					page: result.data.pages[result.data.pages.length - 1]?.page,
+				}
+			: undefined,
+	};
+}

--- a/sdk/src/react/hooks/data/tokens/useSearchTokenMetadata.test.tsx
+++ b/sdk/src/react/hooks/data/tokens/useSearchTokenMetadata.test.tsx
@@ -1,0 +1,114 @@
+import { PropertyType } from '@0xsequence/metadata';
+import { renderHook, server, waitFor } from '@test';
+import { HttpResponse, http } from 'msw';
+import { zeroAddress } from 'viem';
+import { describe, expect, it } from 'vitest';
+import {
+	mockMetadataEndpoint,
+	mockTokenMetadata,
+} from '../../../_internal/api/__mocks__/metadata.msw';
+import type { UseSearchTokenMetadataParams } from './useSearchTokenMetadata';
+import { useSearchTokenMetadata } from './useSearchTokenMetadata';
+
+describe('useSearchTokenMetadata', () => {
+	const defaultArgs: UseSearchTokenMetadataParams = {
+		chainId: 1,
+		collectionAddress: zeroAddress,
+		filter: {
+			text: 'test',
+		},
+	};
+
+	const defaultArgsWithProperties: UseSearchTokenMetadataParams = {
+		chainId: 1,
+		collectionAddress: zeroAddress,
+		filter: {
+			properties: [
+				{
+					name: 'Rarity',
+					type: PropertyType.STRING,
+					values: ['Legendary'],
+				},
+				{
+					name: 'Level',
+					type: PropertyType.INT,
+					min: 50,
+					max: 100,
+				},
+			],
+		},
+	};
+
+	it('should fetch metadata with text search successfully', async () => {
+		const { result } = renderHook(() => useSearchTokenMetadata(defaultArgs));
+
+		// Initially loading
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.data).toBeUndefined();
+
+		// Wait for data to be loaded
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Verify the data matches our mock
+		expect(result.current.data).toBeDefined();
+		expect(result.current.data?.tokenMetadata).toEqual([mockTokenMetadata]);
+		expect(result.current.error).toBeNull();
+	});
+
+	it('should fetch metadata with property filters successfully', async () => {
+		const { result } = renderHook(() =>
+			useSearchTokenMetadata(defaultArgsWithProperties),
+		);
+
+		// Initially loading
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.data).toBeUndefined();
+
+		// Wait for data to be loaded
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		// Verify the data matches our mock
+		expect(result.current.data).toBeDefined();
+		expect(result.current.data?.tokenMetadata).toEqual([mockTokenMetadata]);
+		expect(result.current.error).toBeNull();
+	});
+
+	it('should handle error states', async () => {
+		// Override the handler for this test to return an error
+		server.use(
+			http.post(mockMetadataEndpoint('SearchTokenMetadata'), () => {
+				return HttpResponse.json(
+					{ error: { message: 'Failed to search token metadata' } },
+					{ status: 500 },
+				);
+			}),
+		);
+
+		const { result } = renderHook(() => useSearchTokenMetadata(defaultArgs));
+
+		await waitFor(() => {
+			expect(result.current.isError).toBe(true);
+		});
+
+		expect(result.current.error).toBeDefined();
+		expect(result.current.data).toBeUndefined();
+	});
+
+	it('should respect enabled option in query config', () => {
+		const { result } = renderHook(() =>
+			useSearchTokenMetadata({
+				...defaultArgs,
+				query: {
+					enabled: false,
+				},
+			}),
+		);
+
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.data).toBeUndefined();
+	});
+});

--- a/sdk/src/react/hooks/data/tokens/useSearchTokenMetadata.tsx
+++ b/sdk/src/react/hooks/data/tokens/useSearchTokenMetadata.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { Optional } from '../../../_internal';
+import {
+	type SearchTokenMetadataQueryOptions,
+	searchTokenMetadataQueryOptions,
+} from '../../../queries/searchTokenMetadata';
+import { useConfig } from '../../config/useConfig';
+
+export type UseSearchTokenMetadataParams = Optional<
+	SearchTokenMetadataQueryOptions,
+	'config'
+>;
+
+/**
+ * Hook to search token metadata using filters
+ *
+ * Searches for tokens in a collection based on text and property filters.
+ * Supports filtering by attributes, ranges, and text search.
+ *
+ * @param params - Configuration parameters
+ * @param params.chainId - The chain ID (must be number, e.g., 1 for Ethereum, 137 for Polygon)
+ * @param params.collectionAddress - The collection contract address
+ * @param params.filter - Filter criteria for the search
+ * @param params.filter.text - Optional text search query
+ * @param params.filter.properties - Optional array of property filters
+ * @param params.page - Optional pagination parameters
+ * @param params.query - Optional React Query configuration
+ *
+ * @returns Query result containing matching token metadata
+ *
+ * @example
+ * Basic text search:
+ * ```typescript
+ * const { data, isLoading } = useSearchTokenMetadata({
+ *   chainId: 137,
+ *   collectionAddress: '0x...',
+ *   filter: {
+ *     text: 'dragon'
+ *   }
+ * })
+ * ```
+ *
+ * @example
+ * Property filters:
+ * ```typescript
+ * const { data } = useSearchTokenMetadata({
+ *   chainId: 1,
+ *   collectionAddress: '0x...',
+ *   filter: {
+ *     properties: [
+ *       {
+ *         name: 'Rarity',
+ *         type: PropertyType.STRING,
+ *         values: ['Legendary', 'Epic']
+ *       },
+ *       {
+ *         name: 'Level',
+ *         type: PropertyType.INT,
+ *         min: 50,
+ *         max: 100
+ *       }
+ *     ]
+ *   }
+ * })
+ * ```
+ *
+ * @example
+ * With pagination:
+ * ```typescript
+ * const { data } = useSearchTokenMetadata({
+ *   chainId: 137,
+ *   collectionAddress: '0x...',
+ *   filter: { text: 'rare' },
+ *   page: {
+ *     page: 2,
+ *     pageSize: 20
+ *   }
+ * })
+ * ```
+ */
+export function useSearchTokenMetadata(params: UseSearchTokenMetadataParams) {
+	const defaultConfig = useConfig();
+
+	const { config = defaultConfig, ...rest } = params;
+
+	const queryOptions = searchTokenMetadataQueryOptions({
+		config,
+		...rest,
+	});
+
+	return useQuery({
+		...queryOptions,
+	});
+}

--- a/sdk/src/react/queries/index.ts
+++ b/sdk/src/react/queries/index.ts
@@ -30,4 +30,5 @@ export * from './marketCurrencies';
 export * from './marketplaceConfig';
 export * from './primarySaleItems';
 export * from './primarySaleItemsCount';
+export * from './searchTokenMetadata';
 export * from './tokenSupplies';

--- a/sdk/src/react/queries/searchTokenMetadata.ts
+++ b/sdk/src/react/queries/searchTokenMetadata.ts
@@ -1,0 +1,74 @@
+import type { Filter, Page } from '@0xsequence/metadata';
+import { queryOptions } from '@tanstack/react-query';
+import type { SdkConfig } from '../../types';
+import {
+	getMetadataClient,
+	tokenKeys,
+	type ValuesOptional,
+} from '../_internal';
+import type { StandardQueryOptions } from '../types/query';
+
+export interface FetchSearchTokenMetadataParams {
+	chainId: number;
+	collectionAddress: string;
+	filter: Filter;
+	page?: Page;
+	config: SdkConfig;
+}
+
+/**
+ * Fetches token metadata from the metadata API using search filters
+ */
+export async function fetchSearchTokenMetadata(
+	params: FetchSearchTokenMetadataParams,
+) {
+	const { chainId, collectionAddress, filter, page, config } = params;
+	const metadataClient = getMetadataClient(config);
+
+	const response = await metadataClient.searchTokenMetadata({
+		chainID: chainId.toString(),
+		contractAddress: collectionAddress,
+		filter,
+		page,
+	});
+
+	return {
+		tokenMetadata: response.tokenMetadata,
+		page: response.page,
+	};
+}
+
+export type SearchTokenMetadataQueryOptions =
+	ValuesOptional<FetchSearchTokenMetadataParams> & {
+		query?: StandardQueryOptions;
+	};
+
+export function searchTokenMetadataQueryOptions(
+	params: SearchTokenMetadataQueryOptions,
+) {
+	const enabled = Boolean(
+		params.chainId &&
+			params.collectionAddress &&
+			params.filter &&
+			params.config &&
+			(params.query?.enabled ?? true),
+	);
+
+	return queryOptions({
+		queryKey: [...tokenKeys.metadata, 'search', params],
+		queryFn: () =>
+			fetchSearchTokenMetadata({
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				chainId: params.chainId!,
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				collectionAddress: params.collectionAddress!,
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				filter: params.filter!,
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				config: params.config!,
+				page: params.page,
+			}),
+		...params.query,
+		enabled,
+	});
+}


### PR DESCRIPTION
`useSearchTokenMetadata` is for getting metadata of tokens of a items contract with pagination, but it returns metadata of both minted and unminted tokens. So, I implemented [useSearchMintedTokenMetadata](https://github.com/0xsequence/marketplace-sdk/pull/472/commits/609be83f3bdad51a8aaa56810396769bfd944932) as well for exact use case for marketplace app