### PR TITLE
use `object-contain` for collectible card media

### DIFF
--- a/sdk/src/react/ui/components/marketplace-collectible-card/components/BaseCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/components/BaseCard.tsx
@@ -12,7 +12,6 @@ export interface BaseCardProps extends MarketplaceCardBaseProps {
 	animationUrl?: string;
 	onClick?: () => void;
 	onKeyDown?: (e: React.KeyboardEvent) => void;
-	className?: string;
 	children: React.ReactNode;
 }
 
@@ -24,7 +23,6 @@ export function BaseCard({
 	animationUrl,
 	onClick,
 	onKeyDown,
-	className,
 	assetSrcPrefixUrl,
 	children,
 }: BaseCardProps) {
@@ -48,7 +46,7 @@ export function BaseCard({
 						name={name || ''}
 						assets={[image, video, animationUrl]}
 						assetSrcPrefixUrl={assetSrcPrefixUrl}
-						className={className}
+						mediaClassname="object-contain"
 					/>
 					{children}
 				</article>


### PR DESCRIPTION
<img width="607" height="826" alt="Screenshot 2025-07-31 at 11 03 37" src="https://github.com/user-attachments/assets/e26dcf00-98df-4ffb-a0be-4761cdde4c5e" />
