### PR TITLE
Fix collectible card image opacity

### DIFF
--- a/playgrounds/shared/src/components/ERC721SaleControls.tsx
+++ b/playgrounds/shared/src/components/ERC721SaleControls.tsx
@@ -3,7 +3,6 @@ import {
 	CartIcon,
 	Progress,
 	Skeleton,
-	Switch,
 	Text,
 	WalletIcon,
 } from '@0xsequence/design-system';
@@ -11,7 +10,6 @@ import { ContractType } from '@0xsequence/marketplace-sdk';
 import {
 	useBuyModal,
 	useCurrency,
-	useFilterState,
 	useOpenConnectModal,
 	useShopCollectibleSaleData,
 } from '@0xsequence/marketplace-sdk/react';
@@ -36,7 +34,6 @@ export function ERC721SaleControls({
 	const { address } = useAccount();
 	const { openConnectModal } = useOpenConnectModal();
 	const [quantity, setQuantity] = useState(1);
-	const { setShowListedOnly, showListedOnly } = useFilterState();
 
 	const {
 		supplyCap,
@@ -163,16 +160,6 @@ export function ERC721SaleControls({
 					)}{' '}
 					{currency?.symbol})
 				</Text>
-
-				<div className="flex flex-1 items-center justify-end gap-2">
-					<Text variant="small" color="text80">
-						Show Available Only
-					</Text>
-					<Switch
-						checked={showListedOnly}
-						onCheckedChange={() => setShowListedOnly(!showListedOnly)}
-					/>
-				</div>
 			</div>
 		</div>
 	);

--- a/playgrounds/shared/src/components/collections/CollectionCard.tsx
+++ b/playgrounds/shared/src/components/collections/CollectionCard.tsx
@@ -6,6 +6,7 @@ import {
 } from '@0xsequence/design-system';
 import { Media } from '@0xsequence/marketplace-sdk/react';
 import type { ContractInfo } from '@0xsequence/metadata';
+import { ContractType } from '../../../../../sdk/src';
 import { NetworkPill } from './NetworkPill';
 
 export interface CollectionCardProps {
@@ -15,6 +16,7 @@ export interface CollectionCardProps {
 
 export function CollectionCard({ collection, onClick }: CollectionCardProps) {
 	const truncatedAddress = truncateAddress(collection.address, 4);
+	const contractType = collection.type;
 
 	return (
 		<Card
@@ -25,6 +27,29 @@ export function CollectionCard({ collection, onClick }: CollectionCardProps) {
 		>
 			<NetworkPill chainId={collection.chainId as number} />
 
+			{contractType === ContractType.ERC1155 && (
+				<div className="absolute top-0 right-0 z-30">
+					<Text
+						variant="small"
+						color="text50"
+						className="flex items-center bg-background-primary p-2"
+					>
+						ERC1155
+					</Text>
+				</div>
+			)}
+
+			{contractType === ContractType.ERC721 && (
+				<div className="absolute top-0 right-0 z-30">
+					<Text
+						variant="small"
+						color="text50"
+						className="flex items-center bg-background-primary p-2"
+					>
+						ERC721
+					</Text>
+				</div>
+			)}
 			<Media
 				assets={[collection.extensions.ogImage]}
 				className="h-full w-full object-cover transition-transform duration-500 ease-in-out group-hover:scale-110"

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -53,7 +53,10 @@ export function ShopCard({
 
 	const action = CollectibleCardAction.BUY;
 
-	const mediaClassName = !quantityRemaining ? 'opacity-50' : 'opacity-100';
+	const mediaClassName =
+		quantityRemaining === '0' || quantityRemaining === undefined
+			? 'opacity-50'
+			: 'opacity-100';
 
 	return (
 		<BaseCard


### PR DESCRIPTION
* Fix collectible card image classname to check if either `quantityRemaining` is undefined or it's 0.
* Enhance playground components to work with 1155 sales well.