### PR TITLE
Inventory include shop collections without market setup

### DIFF
--- a/playgrounds/shared/src/components/pages/InventoryPageController.tsx
+++ b/playgrounds/shared/src/components/pages/InventoryPageController.tsx
@@ -2,7 +2,7 @@ import { NetworkImage, Text } from '@0xsequence/design-system';
 import {
 	type CollectibleCardAction,
 	type CollectibleOrder,
-	ContractType,
+	type ContractType,
 	getNetwork,
 	type Order,
 	OrderbookKind,
@@ -44,7 +44,6 @@ interface UseListInventoryCardDataProps {
 	collectionAddress: Address;
 	chainId: number;
 	orderbookKind: OrderbookKind;
-	collectionType: ContractType;
 	onCollectibleClick?: (tokenId: string) => void;
 	onCannotPerformAction?: (action: CollectibleCardAction) => void;
 	assetSrcPrefixUrl?: string;
@@ -54,7 +53,6 @@ function useListInventoryCardData({
 	collectionAddress,
 	chainId,
 	orderbookKind,
-	collectionType,
 	onCollectibleClick,
 	onCannotPerformAction,
 	assetSrcPrefixUrl,
@@ -79,6 +77,8 @@ function useListInventoryCardData({
 			enabled: !!accountAddress && !!collectionAddress && !!chainId,
 		},
 	});
+	const collectionType = inventoryData?.pages[0]?.collectibles[0]
+		?.contractType as ContractType;
 	const isTradable = inventoryData?.pages[0]?.isTradable;
 
 	// Flatten all collectibles from all pages
@@ -251,7 +251,6 @@ function CollectionInventory({
 		chainId,
 		collectionAddress,
 		orderbookKind: OrderbookKind.sequence_marketplace_v2,
-		collectionType: ContractType.ERC721,
 		onCollectibleClick: (tokenId: string) =>
 			onCollectibleClick(chainId, collectionAddress, tokenId),
 	});
@@ -295,6 +294,7 @@ function CollectionInventory({
 								...card,
 								marketplaceType: card.marketplaceType as 'market',
 								prioritizeOwnerActions: true,
+								isTradable,
 							}}
 						/>
 					</div>

--- a/playgrounds/shared/src/components/pages/InventoryPageController.tsx
+++ b/playgrounds/shared/src/components/pages/InventoryPageController.tsx
@@ -163,7 +163,17 @@ export function InventoryPageController({
 	const { data: marketplaceConfig } = useMarketplaceConfig();
 
 	const marketCollections = marketplaceConfig?.market.collections || [];
-	const shopCollections = marketplaceConfig?.shop.collections || [];
+	const allShopCollections = marketplaceConfig?.shop.collections || [];
+
+	// Filter out collections from shopCollections that already exist in marketCollections
+	const shopCollections = allShopCollections.filter(
+		(shopCollection) =>
+			!marketCollections.some(
+				(marketCollection) =>
+					marketCollection.chainId === shopCollection.chainId &&
+					marketCollection.itemsAddress === shopCollection.itemsAddress,
+			),
+	);
 
 	const handleCollectibleClick = (
 		chainId: number,

--- a/playgrounds/shared/src/components/pages/InventoryPageController.tsx
+++ b/playgrounds/shared/src/components/pages/InventoryPageController.tsx
@@ -79,6 +79,7 @@ function useListInventoryCardData({
 			enabled: !!accountAddress && !!collectionAddress && !!chainId,
 		},
 	});
+	const isTradable = inventoryData?.pages[0]?.isTradable;
 
 	// Flatten all collectibles from all pages
 	const allCollectibles = useMemo(() => {
@@ -139,6 +140,7 @@ function useListInventoryCardData({
 	]);
 
 	return {
+		isTradable,
 		collectibleCards,
 		isLoading: inventoryIsLoading,
 		error: inventoryError,
@@ -160,7 +162,8 @@ export function InventoryPageController({
 	const { address: accountAddress } = useAccount();
 	const { data: marketplaceConfig } = useMarketplaceConfig();
 
-	const collections = marketplaceConfig?.market.collections || [];
+	const marketCollections = marketplaceConfig?.market.collections || [];
+	const shopCollections = marketplaceConfig?.shop.collections || [];
 
 	const handleCollectibleClick = (
 		chainId: number,
@@ -184,15 +187,41 @@ export function InventoryPageController({
 
 	return (
 		<div className="flex flex-col gap-6 pt-3">
-			{collections.map((collection) => (
-				<CollectionInventory
-					key={`${collection.chainId}-${collection.itemsAddress}`}
-					chainId={collection.chainId}
-					collectionAddress={collection.itemsAddress as Hex}
-					accountAddress={accountAddress}
-					onCollectibleClick={handleCollectibleClick}
-				/>
-			))}
+			{/* Tradable Collections Section */}
+			{marketCollections.length > 0 && (
+				<>
+					<div className="flex flex-col gap-3">
+						<Text variant="large">Tradable Collections</Text>
+					</div>
+					{marketCollections.map((collection) => (
+						<CollectionInventory
+							key={`${collection.chainId}-${collection.itemsAddress}`}
+							chainId={collection.chainId}
+							collectionAddress={collection.itemsAddress as Hex}
+							accountAddress={accountAddress}
+							onCollectibleClick={handleCollectibleClick}
+						/>
+					))}
+				</>
+			)}
+
+			{/* Shop Collections Section */}
+			{shopCollections.length > 0 && (
+				<>
+					<div className="flex flex-col gap-3">
+						<Text variant="large">Shop Collections</Text>
+					</div>
+					{shopCollections.map((collection) => (
+						<CollectionInventory
+							key={`${collection.chainId}-${collection.itemsAddress}`}
+							chainId={collection.chainId}
+							collectionAddress={collection.itemsAddress as Hex}
+							accountAddress={accountAddress}
+							onCollectibleClick={handleCollectibleClick}
+						/>
+					))}
+				</>
+			)}
 		</div>
 	);
 }
@@ -217,6 +246,7 @@ function CollectionInventory({
 		collectibleCards,
 		isLoading: cardsLoading,
 		allCollectibles,
+		isTradable,
 	} = useListInventoryCardData({
 		chainId,
 		collectionAddress,
@@ -246,6 +276,9 @@ function CollectionInventory({
 			<div className="flex items-center gap-2">
 				<NetworkPill chainId={chainId} />
 				<Text variant="large">{collectionAddress}</Text>
+				<Text variant="small" color="text80">
+					{isTradable ? '(Tradable)' : '(Shop Collection)'}
+				</Text>
 			</div>
 			<div
 				className="flex gap-3"

--- a/sdk/src/react/hooks/data/market/useListMarketCardData.tsx
+++ b/sdk/src/react/hooks/data/market/useListMarketCardData.tsx
@@ -124,6 +124,7 @@ export function useListMarketCardData({
 						return;
 					}
 				},
+				isTradable: true,
 			};
 
 			return cardProps;

--- a/sdk/src/react/queries/listCollectibles.ts
+++ b/sdk/src/react/queries/listCollectibles.ts
@@ -43,7 +43,7 @@ export async function fetchListCollectibles(
 	);
 
 	// If it's not a market collection, return an empty list. those collections are not compatible with the ListCollectibles endpoint.
-	if (!params.enabled || !isMarketCollection) {
+	if (params.enabled === false || !isMarketCollection) {
 		return {
 			collectibles: [],
 			page: {

--- a/sdk/src/react/ui/components/marketplace-collectible-card/types.ts
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/types.ts
@@ -18,6 +18,7 @@ type MarketplaceCardBaseProps = {
 	assetSrcPrefixUrl?: string;
 	cardLoading?: boolean;
 	marketplaceType?: MarketplaceType;
+	isTradable?: boolean;
 };
 
 // Properties specific to Shop card

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/MarketCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/MarketCard.tsx
@@ -23,6 +23,7 @@ export function MarketCard({
 	balanceIsLoading = false,
 	onCannotPerformAction,
 	prioritizeOwnerActions,
+	isTradable,
 }: MarketCollectibleCardProps) {
 	const collectibleMetadata = collectible?.metadata;
 	const highestOffer = collectible?.offer;
@@ -46,7 +47,7 @@ export function MarketCard({
 	}
 
 	const showActionButton =
-		!balanceIsLoading && (!!highestOffer || !!collectible);
+		!balanceIsLoading && (!!highestOffer || !!collectible) && isTradable;
 
 	const action = (
 		balance
@@ -107,7 +108,7 @@ export function MarketCard({
 			/>
 
 			<ActionButtonWrapper
-				show={showActionButton}
+				show={showActionButton ?? false}
 				chainId={chainId}
 				collectionAddress={collectionAddress}
 				tokenId={collectibleId}


### PR DESCRIPTION
https://github.com/0xsequence/issue-tracker/issues/5637

If user purchased a sale item from a collection that is not set up for marketplace via Builder, we used to not show those tokens in inventory.
This PR is for to show them without any actions user can take, with flag `isTradable`

<img width="1284" height="1789" alt="screencapture-localhost-4444-inventory-2025-08-13-14_58_24" src="https://github.com/user-attachments/assets/91c3fcac-3c9f-4e0a-a449-e5b2db184cef" />
