### PR TITLE
Remove usage of marketplace query provider

### DIFF
--- a/sdk/src/react/providers/index.tsx
+++ b/sdk/src/react/providers/index.tsx
@@ -58,13 +58,11 @@ export function MarketplaceProvider({
 		};
 
 		return (
-			<MarketplaceQueryClientProvider>
-				<MarketplaceSdkContext.Provider value={context}>
-					<ThemeProvider>
-						<div id={PROVIDER_ID}>{children}</div>
-					</ThemeProvider>
-				</MarketplaceSdkContext.Provider>
-			</MarketplaceQueryClientProvider>
+			<MarketplaceSdkContext.Provider value={context}>
+				<ThemeProvider>
+					<div id={PROVIDER_ID}>{children}</div>
+				</ThemeProvider>
+			</MarketplaceSdkContext.Provider>
 		);
 	}
 
@@ -103,10 +101,8 @@ function MarketplaceProviderWithSequenceConnect({
 	};
 
 	return (
-		<MarketplaceQueryClientProvider>
-			<MarketplaceSdkContext.Provider value={context}>
-				<div id={PROVIDER_ID}>{children}</div>
-			</MarketplaceSdkContext.Provider>
-		</MarketplaceQueryClientProvider>
+		<MarketplaceSdkContext.Provider value={context}>
+			<div id={PROVIDER_ID}>{children}</div>
+		</MarketplaceSdkContext.Provider>
 	);
 }


### PR DESCRIPTION
We have a marketplace query provider in the providers-setup for the Marketplace SDK.
The thought was probably that the consuming app could avoid setting one up, but in practice, this prevents errors from bubbling up, and you most likely want the query boundary to be higher than the SDK anyway