### PR TITLE
Update ShopCard component to handle unlimited supply condition

### DIFF
--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -53,8 +53,9 @@ export function ShopCard({
 
 	const action = CollectibleCardAction.BUY;
 
-	const mediaClassName =
-		quantityRemaining === '0' || quantityRemaining === undefined
+	const mediaClassName = unlimitedSupply
+		? 'opacity-100'
+		: quantityRemaining === '0' || quantityRemaining === undefined
 			? 'opacity-50'
 			: 'opacity-100';
 


### PR DESCRIPTION
- Modified the mediaClassName logic to apply an opacity of 100% when the collectible has an unlimited supply.