### PR TITLE
Enhance loading state and skeleton management of collectible cards

### DIFF
--- a/sdk/src/react/hooks/data/primary-sales/useList1155ShopCardData.tsx
+++ b/sdk/src/react/hooks/data/primary-sales/useList1155ShopCardData.tsx
@@ -37,6 +37,9 @@ export function useList1155ShopCardData({
 	const { data: collection, isLoading: collectionLoading } = useCollection({
 		chainId,
 		collectionAddress: contractAddress,
+		query: {
+			enabled,
+		},
 	});
 
 	const { data: paymentToken, isLoading: paymentTokenLoading } =
@@ -50,7 +53,7 @@ export function useList1155ShopCardData({
 			},
 		});
 
-	const isLoading = collectionLoading || paymentTokenLoading;
+	const isLoading = versionLoading || collectionLoading || paymentTokenLoading;
 
 	const collectibleCards = primarySaleItemsWithMetadata.map((item) => {
 		const { metadata, primarySaleItem: saleData } = item;
@@ -88,6 +91,6 @@ export function useList1155ShopCardData({
 		collectibleCards,
 		tokenMetadataError: null,
 		tokenSaleDetailsError: null,
-		isLoading,
+		isLoading: enabled && isLoading,
 	};
 }

--- a/sdk/src/react/hooks/data/primary-sales/useList721ShopCardData.tsx
+++ b/sdk/src/react/hooks/data/primary-sales/useList721ShopCardData.tsx
@@ -81,6 +81,7 @@ export function useList721ShopCardData({
 		isFetchingNextSuppliesPage,
 		tokenSuppliesLoading,
 		fetchNextTokenSuppliesPage,
+		tokenSuppliesEnabled,
 	]);
 
 	const allTokenSupplies = tokenSuppliesData?.pages.flatMap(
@@ -186,7 +187,8 @@ export function useList721ShopCardData({
 		saleDetailsError,
 		saleDetails,
 		isLoading:
-			saleDetailsLoading || tokenSuppliesLoading || !allTokenSuppliesFetched,
+			enabled &&
+			(saleDetailsLoading || tokenSuppliesLoading || !allTokenSuppliesFetched),
 		tokenSuppliesData,
 	};
 }

--- a/sdk/src/react/ui/components/marketplace-collectible-card/CollectibleCardSkeleton.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/CollectibleCardSkeleton.tsx
@@ -1,6 +1,13 @@
 import { Skeleton } from '@0xsequence/design-system';
+import { ContractType } from '../../../_internal';
 
-export function MarketplaceCollectibleCardSkeleton() {
+export function MarketplaceCollectibleCardSkeleton({
+	contractType,
+	isShop,
+}: {
+	contractType: ContractType;
+	isShop: boolean;
+}) {
 	return (
 		<div
 			data-testid="collectible-card-skeleton"
@@ -17,7 +24,11 @@ export function MarketplaceCollectibleCardSkeleton() {
 			</div>
 			<div className="mt-2 flex flex-col gap-2 px-4 pb-4">
 				<Skeleton size="lg" className="animate-shimmer" />
-				<Skeleton size="sm" className="animate-shimmer" />
+				<Skeleton size="sm" className="h-5 w-16 animate-shimmer" />
+
+				{isShop && contractType === ContractType.ERC1155 && (
+					<Skeleton size="lg" className="h-6 w-20 animate-shimmer" />
+				)}
 			</div>
 		</div>
 	);

--- a/sdk/src/react/ui/components/marketplace-collectible-card/components/BaseCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/components/BaseCard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { cn } from '@0xsequence/design-system';
+import type { ContractType } from '../../../../_internal';
 import { Media } from '../../media/Media';
 import { MarketplaceCollectibleCardSkeleton } from '../CollectibleCardSkeleton';
 import type { MarketplaceCardBaseProps } from '../types';
-
 export interface BaseCardProps extends MarketplaceCardBaseProps {
 	cardLoading: boolean;
 	name: string;
@@ -15,6 +15,8 @@ export interface BaseCardProps extends MarketplaceCardBaseProps {
 	onKeyDown?: (e: React.KeyboardEvent) => void;
 	children: React.ReactNode;
 	mediaClassName?: string;
+	contractType: ContractType;
+	isShop: boolean;
 }
 
 export function BaseCard({
@@ -28,9 +30,16 @@ export function BaseCard({
 	children,
 	mediaClassName,
 	cardLoading,
+	contractType,
+	isShop,
 }: BaseCardProps) {
 	if (cardLoading) {
-		return <MarketplaceCollectibleCardSkeleton />;
+		return (
+			<MarketplaceCollectibleCardSkeleton
+				contractType={contractType}
+				isShop={isShop}
+			/>
+		);
 	}
 
 	return (

--- a/sdk/src/react/ui/components/marketplace-collectible-card/components/footer/Footer.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/components/footer/Footer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Text } from '@0xsequence/design-system';
+import { Skeleton, Text } from '@0xsequence/design-system';
 import type { Address } from 'viem';
 import type { CardType } from '../../../../../../types';
+import { cn } from '../../../../../../utils';
 import {
 	ContractType,
 	type Currency,
@@ -55,16 +56,17 @@ export const Footer = ({
 	const isMarket = cardType === 'market';
 	const isInventoryNonTradable = cardType === 'inventory-non-tradable';
 
-	const { data: lowestListing } = useLowestListing({
-		chainId,
-		collectionAddress,
-		tokenId: collectibleId,
-		query: {
-			enabled: isMarket, // Only fetch for market cards
-		},
-	});
+	const { data: lowestListing, isLoading: isLowestListingLoading } =
+		useLowestListing({
+			chainId,
+			collectionAddress,
+			tokenId: collectibleId,
+			query: {
+				enabled: isMarket, // Only fetch for market cards
+			},
+		});
 
-	const { data: currency } = useCurrency({
+	const { data: currency, isLoading: isCurrencyLoading } = useCurrency({
 		chainId,
 		currencyAddress: lowestListing?.priceCurrencyAddress as Address,
 		query: {
@@ -74,6 +76,12 @@ export const Footer = ({
 
 	const listed =
 		!!lowestListing?.priceAmount && !!lowestListing?.priceCurrencyAddress;
+
+	// Show loading state when listing is loading, or when listing exists but currency is still loading
+	const isPriceLoading =
+		isMarket &&
+		(isLowestListingLoading ||
+			(!!lowestListing?.priceCurrencyAddress && isCurrencyLoading));
 
 	return (
 		<div className="relative flex flex-col items-start gap-2 whitespace-nowrap bg-background-primary p-4">
@@ -86,8 +94,17 @@ export const Footer = ({
 				quantityRemaining={quantityRemaining}
 			/>
 
-			<div className="flex items-center gap-1">
-				{listed && isMarket && lowestListing && currency && (
+			<div
+				className={cn(
+					'flex items-center gap-1',
+					isShop && type === ContractType.ERC721 && 'hidden',
+				)}
+			>
+				{isPriceLoading && (
+					<Skeleton size="sm" className="h-5 w-20 animate-shimmer" />
+				)}
+
+				{!isPriceLoading && listed && isMarket && lowestListing && currency && (
 					<PriceDisplay
 						amount={lowestListing.priceAmount}
 						currency={currency}
@@ -95,7 +112,7 @@ export const Footer = ({
 					/>
 				)}
 
-				{!listed && isMarket && (
+				{!isPriceLoading && !listed && isMarket && (
 					<Text className="text-left font-body font-bold text-sm text-text-50">
 						Not listed yet
 					</Text>

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/MarketCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/MarketCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CollectibleCardAction } from '../../../../../types';
+import type { ContractType } from '../../../../_internal';
 import { ActionButtonWrapper } from '../components/ActionButtonWrapper';
 import { BaseCard } from '../components/BaseCard';
 import { Footer } from '../components/footer';
@@ -61,6 +62,8 @@ export function MarketCard({
 			image={collectibleMetadata.image}
 			video={collectibleMetadata.video}
 			animationUrl={collectibleMetadata.animation_url}
+			contractType={collectionType as ContractType}
+			isShop={false}
 			onClick={() => onCollectibleClick?.(collectibleId)}
 			onKeyDown={handleKeyDown}
 		>

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/NonTradableInventoryCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/NonTradableInventoryCard.tsx
@@ -27,6 +27,8 @@ export function NonTradableInventoryCard({
 			collectionType={collectionType}
 			assetSrcPrefixUrl={assetSrcPrefixUrl}
 			cardLoading={cardLoading || balanceIsLoading}
+			contractType={collectionType as ContractType}
+			isShop={false}
 			name={collectibleMetadata.name}
 		>
 			<NonTradableInventoryFooter

--- a/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
+++ b/sdk/src/react/ui/components/marketplace-collectible-card/variants/ShopCard.tsx
@@ -71,6 +71,8 @@ export function ShopCard({
 			video={tokenMetadata.video}
 			animationUrl={tokenMetadata.animation_url}
 			mediaClassName={mediaClassName}
+			contractType={collectionType as ContractType}
+			isShop={true}
 		>
 			<Footer
 				chainId={chainId}


### PR DESCRIPTION
Shop collectible cards were flickering. I fixed it by passing missing `isLoading` states of hooks and refactored showing skeletons for both market & shop cards properly.