### PR TITLE
fix: Update PriceInput component to conditionally render text based on modal type

### DIFF
--- a/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/priceInput/index.tsx
@@ -199,7 +199,8 @@ export default function PriceInput({
 				priceAmountRaw !== '0' &&
 				!openseaLowestPriceCriteriaMet &&
 				orderbookKind === OrderbookKind.opensea &&
-				!isConversionLoading && (
+				!isConversionLoading &&
+				modalType === 'offer' && (
 					<Text
 						className="-bottom-5 absolute font-body font-medium text-xs"
 						color="negative"


### PR DESCRIPTION
Opensea lowest offer price error:
- Added a condition to the PriceInput component to display a text element only when the modal type is 'offer', in addition to existing conditions.
- This change enhances the user interface by ensuring relevant information is shown based on the context of the modal.