### PR TITLE
Add LoadingModal to ERC1155BuyModal for improved loading state handling

### DIFF
--- a/sdk/src/react/ui/modals/BuyModal/components/ERC1155BuyModal.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/components/ERC1155BuyModal.tsx
@@ -19,6 +19,7 @@ import {
 	useQuantity,
 } from '../store';
 import { ERC1155QuantityModal } from './ERC1155QuantityModal';
+import { LoadingModal } from '../../_internal/components/actionModal/LoadingModal';
 
 interface ERC1155BuyModalProps {
 	collection: ContractInfo;
@@ -156,7 +157,14 @@ const Modal = ({
 	}
 
 	if (isPaymentModalParamsLoading || !paymentModalParams) {
-		return null;
+		return (
+			<LoadingModal
+				isOpen={true}
+				chainId={order.chainId}
+				onClose={() => buyModalStore.send({ type: 'close' })}
+				title="Loading checkout"
+			/>
+		);
 	}
 
 	if (isPaymentModalParamsError) {


### PR DESCRIPTION
We returned null while waiting payment params are loading, while we should have rendered a loading modal instead, between quantity selection and checkout modal state. User could click something else than checkout flow, i.e. click on make offer modal 👇🏼

- Integrated LoadingModal component to display a loading state when payment modal parameters are being fetched.
- This enhancement provides users with visual feedback during the checkout process, improving overall user experience

BEFORE

https://github.com/user-attachments/assets/070cc558-ba2f-4dfe-a840-f63a26eddc1d

AFTER

https://github.com/user-attachments/assets/2f3130a2-6182-4ba0-a62e-4e476ab12ad1

