### PR TITLE
Add setToEndOfDay utility function to CalendarDropdown

### DIFF
--- a/sdk/src/react/ui/modals/_internal/components/calendarDropdown/index.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/calendarDropdown/index.tsx
@@ -13,6 +13,12 @@ import SvgCalendarIcon from '../../../../icons/CalendarIcon';
 import Calendar from '../calendar';
 import { PRESET_RANGES, type RangeType } from '../expirationDateSelect';
 
+const setToEndOfDay = (date: Date): Date => {
+	const endOfDay = new Date(date);
+	endOfDay.setHours(23, 59, 59, 999);
+	return endOfDay;
+};
+
 type CalendarDropdownProps = {
 	selectedDate: Date;
 	setSelectedDate: (date: Date) => void;
@@ -101,7 +107,8 @@ export default function CalendarDropdown({
 						<Calendar
 							selectedDate={selectedDate}
 							setSelectedDate={(date) => {
-								setSelectedDate(date);
+								const finalDate = setToEndOfDay(date);
+								setSelectedDate(finalDate);
 								setIsOpen(false);
 							}}
 							mode="single"


### PR DESCRIPTION
🪲 When the user selects today from the calendar, the date is set to today, but the time is set to 00:00. This actually corresponds to a past time. At the time I wrote this, it was generating orders 14 hours behind the current time, causing an error.

- Introduced a new utility function, setToEndOfDay, to adjust the selected date to the end of the day (23:59:59.999).
- Updated the setSelectedDate callback to utilize this function, ensuring that the selected date reflects the end of the day when a date is chosen.