### PR TITLE
Calendar styles

### DIFF
--- a/sdk/src/react/ui/modals/_internal/components/calendarDropdown/TimeSelector.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/calendarDropdown/TimeSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { NumericInput, Text } from '@0xsequence/design-system';
+import { NumericInput, Text, TimeIcon } from '@0xsequence/design-system';
 import { getHours, getMinutes, setHours, setMinutes } from 'date-fns';
 import { useRef, useState } from 'react';
 import { clamp } from '../../../../../_internal/utils';
@@ -67,8 +67,10 @@ export function TimeSelector({
 	const minutes = draft?.minutes ?? currentMinutes.toString().padStart(2, '0');
 
 	return (
-		<div className="mt-3 flex flex-col gap-2 border-border-base border-t pt-3">
-			<div className="flex items-center justify-between gap-2">
+		<div className="mt-3 flex items-center gap-6 border-border-base border-t pt-3">
+			<TimeIcon />
+
+			<div className="flex flex-1 items-center justify-between gap-2">
 				<div className="w-16 [&>label]:w-16">
 					<NumericInput
 						className="h-9 [&>input]:text-xs"

--- a/sdk/src/react/ui/modals/_internal/components/calendarDropdown/index.tsx
+++ b/sdk/src/react/ui/modals/_internal/components/calendarDropdown/index.tsx
@@ -1,6 +1,4 @@
 'use client';
-
-import './overrides.css';
 import {
 	Button,
 	DropdownMenuContent,

--- a/sdk/src/react/ui/modals/_internal/components/calendarDropdown/overrides.css
+++ b/sdk/src/react/ui/modals/_internal/components/calendarDropdown/overrides.css
@@ -1,4 +1,5 @@
 .rdp-root {
+	width: 100% !important;
 	padding: 0 !important;
 	user-select: none;
 }
@@ -12,12 +13,25 @@
 	justify-content: space-between;
 }
 
+.rdp-months {
+	width: 100%;
+	max-width: unset !important;
+}
+
 .rdp-month_caption {
 	text-align: center;
 	width: 100%;
 	height: 36px !important;
 	display: block !important;
 	font-size: 14px !important;
+}
+
+.rdp-month_grid {
+	width: 100%;
+}
+
+.rdp-month {
+	width: 100%;
 }
 
 .rdp-button_previous {
@@ -48,11 +62,32 @@
 	height: 16px !important;
 }
 
+.rdp-weekdays {
+	display: flex;
+	justify-content: space-between;
+}
+
 .rdp-weekday {
 	padding: 16px 0 !important;
 	font-size: 14px !important;
 	font-weight: var(--font-weight-medium) !important;
 	color: var(--color-text-80) !important;
+}
+
+.rdp-weeks {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.rdp-week {
+	display: flex;
+	justify-content: space-between;
+}
+
+.rdp-day {
+	width: 24px !important;
+	height: 24px !important;
 }
 
 .rdp-day_button {

--- a/sdk/src/styles/index.css
+++ b/sdk/src/styles/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "@0xsequence/design-system/preset";
 @import "react-day-picker/style.css";
+@import "../react/ui/modals/_internal/components/calendarDropdown/overrides.css";
 
 @source "../";
 

--- a/sdk/src/styles/styles.ts
+++ b/sdk/src/styles/styles.ts
@@ -1001,6 +1001,10 @@ export const styles = String.raw`/* Modified Tailwind CSS, to avoid issues with 
     border-style: var(--tw-border-style);
     border-width: 2px;
   }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
   .border-b-2 {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
@@ -2464,6 +2468,11 @@ export const styles = String.raw`/* Modified Tailwind CSS, to avoid issues with 
       display: flex;
     }
   }
+  .\[\&\>label\]\:w-16 {
+    &>label {
+      width: calc(var(--spacing) * 16);
+    }
+  }
   .\[\&\>label\]\:w-full {
     &>label {
       width: 100%;
@@ -3051,6 +3060,100 @@ export const styles = String.raw`/* Modified Tailwind CSS, to avoid issues with 
 }
 .rdp-caption_before_exit {
   animation: rdp-fade_out var(--rdp-animation_duration) var(--rdp-animation_timing) forwards;
+}
+.rdp-root {
+  width: 100% !important;
+  padding: 0 !important;
+  user-select: none;
+}
+.rdp-nav {
+  position: absolute;
+  width: 100%;
+  height: fit-content !important;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.rdp-months {
+  width: 100%;
+  max-width: unset !important;
+}
+.rdp-month_caption {
+  text-align: center;
+  width: 100%;
+  height: 36px !important;
+  display: block !important;
+  font-size: 14px !important;
+}
+.rdp-month_grid {
+  width: 100%;
+}
+.rdp-month {
+  width: 100%;
+}
+.rdp-button_previous {
+  background-color: var(--color-overlay-light) !important;
+  border-radius: 50%;
+}
+.rdp-button_previous:hover {
+  background-color: var(--color-overlay-glass) !important;
+}
+.rdp-button_previous > svg {
+  fill: var(--color-text-100) !important;
+  width: 16px !important;
+  height: 16px !important;
+}
+.rdp-button_next {
+  background-color: var(--color-overlay-light) !important;
+  border-radius: 50%;
+}
+.rdp-button_next:hover {
+  background-color: var(--color-overlay-glass) !important;
+}
+.rdp-button_next > svg {
+  fill: var(--color-text-100) !important;
+  width: 16px !important;
+  height: 16px !important;
+}
+.rdp-weekdays {
+  display: flex;
+  justify-content: space-between;
+}
+.rdp-weekday {
+  padding: 16px 0 !important;
+  font-size: 14px !important;
+  font-weight: var(--font-weight-medium) !important;
+  color: var(--color-text-80) !important;
+}
+.rdp-weeks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.rdp-week {
+  display: flex;
+  justify-content: space-between;
+}
+.rdp-day {
+  width: 24px !important;
+  height: 24px !important;
+}
+.rdp-day_button {
+  width: 24px !important;
+  height: 24px !important;
+  font-size: var(--text-xs) !important;
+  color: var(--color-text-80) !important;
+}
+.rdp-day_button:disabled {
+  color: var(--color-text-50) !important;
+}
+.rdp-day.rdp-today {
+  outline: 1px solid var(--color-violet-700) !important;
+  border-radius: 50% !important;
+}
+.rdp-day.rdp-selected {
+  background: var(--seq-color-gradient-primary) !important;
+  border-radius: 50% !important;
 }
 @keyframes fadeIn {
   0% {


### PR DESCRIPTION
Issue : https://github.com/0xsequence/issue-tracker/issues/5894#issuecomment-3364613180

`overrides.css` was not included in `compile-tailwind.js` script which generates `styles.ts` for and used in shadow root. This PR is to include it in index.css and makes sure it's classes are added to styles.ts as well.
Also, styles of calendar elements polished.

<img width="545" height="556" alt="Screenshot 2025-10-03 at 14 05 08" src="https://github.com/user-attachments/assets/6f051b94-c534-4664-b98f-5a2ab08782a1" />
