### PR TITLE
Create query keys based on endpoint arguments

### DIFF
--- a/sdk/src/react/_internal/api/query-keys.ts
+++ b/sdk/src/react/_internal/api/query-keys.ts
@@ -28,6 +28,7 @@ class CollectableKeys {
 	static listings = [...CollectableKeys.all, 'listings'] as const;
 	static listingsCount = [...CollectableKeys.all, 'listingsCount'] as const;
 	static listPrimarySaleItems = ['listPrimarySaleItems'] as const;
+	static primarySaleItemsCount = ['primarySaleItemsCount'] as const;
 	static filter = [...CollectableKeys.all, 'filter'] as const;
 	static counts = [...CollectableKeys.all, 'counts'] as const;
 	static collectibleActivities = [
@@ -96,6 +97,7 @@ class TokenKeys {
 	static all = ['tokens'] as const;
 	static metadata = [...TokenKeys.all, 'metadata'] as const;
 	static supplies = [...TokenKeys.all, 'supplies'] as const;
+	static ranges = [...TokenKeys.all, 'ranges'] as const;
 }
 
 // biome-ignore lint/complexity/noStaticOnlyClass: static class provides better organization and type safety for query keys

--- a/sdk/src/react/_internal/types.ts
+++ b/sdk/src/react/_internal/types.ts
@@ -61,4 +61,18 @@ export type ValuesOptional<T> = {
 	[K in keyof T]: T[K] | undefined;
 };
 
+export type RequiredKeys<T> = {
+	[K in keyof T]-?: T[K];
+};
+
+export type QueryKeyArgs<T> = {
+	[K in keyof Required<T>]: T[K] | undefined;
+};
+
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+
+/**
+ * Extracts only API-relevant fields from query params, excluding SDK config and query options
+ * Converts optional properties (prop?: T) to explicit union types (prop: T | undefined)
+ */
+export type ApiArgs<T> = ValuesOptional<Omit<T, 'config' | 'query'>>;

--- a/sdk/src/react/queries/balanceOfCollectible.ts
+++ b/sdk/src/react/queries/balanceOfCollectible.ts
@@ -54,6 +54,27 @@ export async function fetchBalanceOfCollectible(
 		.then((res) => res.balances[0] || null);
 }
 
+export function getBalanceOfCollectibleQueryKey(
+	args: UseBalanceOfCollectibleArgs,
+) {
+	const apiArgs = {
+		chainId: args.chainId,
+		accountAddress: args.userAddress,
+		contractAddress: args.collectionAddress,
+		tokenID: args.collectableId,
+		includeMetadata: args.includeMetadata,
+		metadataOptions: args.userAddress
+			? {
+					verifiedOnly: true,
+					includeContracts: [args.collectionAddress],
+				}
+			: undefined,
+		isLaos721: args.isLaos721,
+	};
+
+	return [...collectableKeys.userBalances, apiArgs] as const;
+}
+
 /**
  * Creates a tanstack query options object for the balance query
  *
@@ -67,7 +88,7 @@ export function balanceOfCollectibleOptions(
 ) {
 	const enabled = !!args.userAddress && (args.query?.enabled ?? true);
 	return queryOptions({
-		queryKey: [...collectableKeys.userBalances, args],
+		queryKey: getBalanceOfCollectibleQueryKey(args),
 		queryFn: enabled
 			? () =>
 					fetchBalanceOfCollectible(

--- a/sdk/src/react/queries/checkoutOptions.ts
+++ b/sdk/src/react/queries/checkoutOptions.ts
@@ -2,7 +2,12 @@ import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
 import type { MarketplaceKind } from '../_internal';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	checkoutKeys,
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	CheckoutOptionsMarketplaceArgs,
 	CheckoutOptionsMarketplaceReturn,
@@ -54,6 +59,23 @@ export type CheckoutOptionsQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCheckoutOptionsQueryKey(
+	params: CheckoutOptionsQueryOptions,
+) {
+	const apiArgs = {
+		chainId: String(params.chainId),
+		wallet: params.walletAddress,
+		orders: params.orders?.map((order) => ({
+			contractAddress: order.collectionAddress,
+			orderId: order.orderId,
+			marketplace: order.marketplace,
+		})),
+		additionalFee: params.additionalFee,
+	} satisfies QueryKeyArgs<CheckoutOptionsMarketplaceArgs>;
+
+	return [...checkoutKeys.options, apiArgs] as const;
+}
+
 export function checkoutOptionsQueryOptions(
 	params: CheckoutOptionsQueryOptions,
 ) {
@@ -66,7 +88,7 @@ export function checkoutOptionsQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: ['checkout', 'options', params],
+		queryKey: getCheckoutOptionsQueryKey(params),
 		queryFn: () =>
 			fetchCheckoutOptions({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/checkoutOptionsSalesContract.ts
+++ b/sdk/src/react/queries/checkoutOptionsSalesContract.ts
@@ -62,16 +62,11 @@ export function getCheckoutOptionsSalesContractQueryKey(
 	params: CheckoutOptionsSalesContractQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		wallet: params.walletAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.contractAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		collectionAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		items: params.items!,
+		chainId: String(params.chainId),
+		wallet: params.walletAddress,
+		contractAddress: params.contractAddress,
+		collectionAddress: params.collectionAddress,
+		items: params.items,
 	} satisfies QueryKeyArgs<CheckoutOptionsSalesContractArgs>;
 
 	return [...checkoutKeys.options, 'salesContract', apiArgs] as const;

--- a/sdk/src/react/queries/checkoutOptionsSalesContract.ts
+++ b/sdk/src/react/queries/checkoutOptionsSalesContract.ts
@@ -1,7 +1,12 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	checkoutKeys,
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	CheckoutOptionsItem,
 	CheckoutOptionsSalesContractArgs,
@@ -53,6 +58,25 @@ export type CheckoutOptionsSalesContractQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCheckoutOptionsSalesContractQueryKey(
+	params: CheckoutOptionsSalesContractQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		wallet: params.walletAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.contractAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		collectionAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		items: params.items!,
+	} satisfies QueryKeyArgs<CheckoutOptionsSalesContractArgs>;
+
+	return [...checkoutKeys.options, 'salesContract', apiArgs] as const;
+}
+
 export function checkoutOptionsSalesContractQueryOptions(
 	params: CheckoutOptionsSalesContractQueryOptions,
 ) {
@@ -67,7 +91,7 @@ export function checkoutOptionsSalesContractQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: ['checkout', 'options', 'salesContract', params],
+		queryKey: getCheckoutOptionsSalesContractQueryKey(params),
 		queryFn: () =>
 			fetchCheckoutOptionsSalesContract({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/collectible.ts
+++ b/sdk/src/react/queries/collectible.ts
@@ -1,7 +1,11 @@
 import type { GetTokenMetadataArgs } from '@0xsequence/metadata';
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMetadataClient, type ValuesOptional } from '../_internal';
+import {
+	getMetadataClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import { collectableKeys } from '../_internal/api/query-keys';
 import type { StandardQueryOptions } from '../types/query';
 
@@ -38,6 +42,17 @@ export type CollectibleQueryOptions = ValuesOptional<FetchCollectibleParams> & {
 	query?: StandardQueryOptions;
 };
 
+export function getCollectibleQueryKey(params: CollectibleQueryOptions) {
+	const apiArgs = {
+		chainID: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		// biome-ignore lint/style/noNonNullAssertion: Dont need to validate here
+		tokenIDs: [params.collectibleId!],
+	} satisfies QueryKeyArgs<GetTokenMetadataArgs>;
+
+	return [...collectableKeys.details, apiArgs] as const;
+}
+
 export function collectibleQueryOptions(params: CollectibleQueryOptions) {
 	const enabled = Boolean(
 		params.collectionAddress &&
@@ -48,7 +63,7 @@ export function collectibleQueryOptions(params: CollectibleQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.details, params],
+		queryKey: getCollectibleQueryKey(params),
 		queryFn: () =>
 			fetchCollectible({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/collection.ts
+++ b/sdk/src/react/queries/collection.ts
@@ -1,6 +1,11 @@
+import type { GetContractInfoArgs } from '@0xsequence/metadata';
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMetadataClient, type ValuesOptional } from '../_internal';
+import {
+	getMetadataClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import { collectionKeys } from '../_internal/api/query-keys';
 import type { StandardQueryOptions } from '../types/query';
 
@@ -30,6 +35,17 @@ export type CollectionQueryOptions = ValuesOptional<FetchCollectionParams> & {
 	query?: StandardQueryOptions;
 };
 
+export function getCollectionQueryKey(params: CollectionQueryOptions) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainID: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+	} satisfies QueryKeyArgs<GetContractInfoArgs>;
+
+	return [...collectionKeys.detail, apiArgs] as const;
+}
+
 export function collectionQueryOptions(params: CollectionQueryOptions) {
 	const enabled = Boolean(
 		params.collectionAddress &&
@@ -39,7 +55,7 @@ export function collectionQueryOptions(params: CollectionQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.detail, params],
+		queryKey: getCollectionQueryKey(params),
 		queryFn: () =>
 			fetchCollection({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/collection.ts
+++ b/sdk/src/react/queries/collection.ts
@@ -37,10 +37,8 @@ export type CollectionQueryOptions = ValuesOptional<FetchCollectionParams> & {
 
 export function getCollectionQueryKey(params: CollectionQueryOptions) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainID: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
+		chainID: String(params.chainId),
+		contractAddress: params.collectionAddress,
 	} satisfies QueryKeyArgs<GetContractInfoArgs>;
 
 	return [...collectionKeys.detail, apiArgs] as const;

--- a/sdk/src/react/queries/collectionBalanceDetails.ts
+++ b/sdk/src/react/queries/collectionBalanceDetails.ts
@@ -2,7 +2,11 @@ import type { GetTokenBalancesDetailsReturn } from '@0xsequence/indexer';
 import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
-import { getIndexerClient, type ValuesOptional } from '../_internal';
+import {
+	balanceQueries,
+	getIndexerClient,
+	type ValuesOptional,
+} from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
 
 export interface CollectionBalanceFilter {
@@ -65,6 +69,17 @@ export type CollectionBalanceDetailsQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCollectionBalanceDetailsQueryKey(
+	params: CollectionBalanceDetailsQueryOptions,
+) {
+	const apiArgs = {
+		chainId: params.chainId!,
+		filter: params.filter!,
+	};
+
+	return [...balanceQueries.collectionBalanceDetails, apiArgs] as const;
+}
+
 export function collectionBalanceDetailsQueryOptions(
 	params: CollectionBalanceDetailsQueryOptions,
 ) {
@@ -76,7 +91,7 @@ export function collectionBalanceDetailsQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: ['balances', 'collectionBalanceDetails', params],
+		queryKey: getCollectionBalanceDetailsQueryKey(params),
 		queryFn: () =>
 			fetchCollectionBalanceDetails({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/collectionDetails.ts
+++ b/sdk/src/react/queries/collectionDetails.ts
@@ -45,10 +45,8 @@ export function getCollectionDetailsQueryKey(
 	params: CollectionDetailsQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
 	} satisfies QueryKeyArgs<GetCollectionDetailArgs>;
 
 	return [...collectionKeys.detail, apiArgs] as const;

--- a/sdk/src/react/queries/collectionDetails.ts
+++ b/sdk/src/react/queries/collectionDetails.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type { GetCollectionDetailArgs } from '../_internal/api/marketplace.gen';
 import { collectionKeys } from '../_internal/api/query-keys';
 import type { StandardQueryOptions } from '../types/query';
@@ -37,6 +41,19 @@ export type CollectionDetailsQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCollectionDetailsQueryKey(
+	params: CollectionDetailsQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+	} satisfies QueryKeyArgs<GetCollectionDetailArgs>;
+
+	return [...collectionKeys.detail, apiArgs] as const;
+}
+
 export function collectionDetailsQueryOptions(
 	params: CollectionDetailsQueryOptions,
 ) {
@@ -48,7 +65,7 @@ export function collectionDetailsQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.detail, params],
+		queryKey: getCollectionDetailsQueryKey(params),
 		queryFn: () =>
 			fetchCollectionDetails({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/comparePrices.ts
+++ b/sdk/src/react/queries/comparePrices.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
-import type { ValuesOptional } from '../_internal';
+import { currencyKeys, type ValuesOptional } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
 import { fetchConvertPriceToUSD } from './convertPriceToUSD';
 
@@ -74,6 +74,18 @@ export type ComparePricesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getComparePricesQueryKey(params: ComparePricesQueryOptions) {
+	const apiArgs = {
+		chainId: params.chainId!,
+		priceAmountRaw: params.priceAmountRaw!,
+		priceCurrencyAddress: params.priceCurrencyAddress!,
+		compareToPriceAmountRaw: params.compareToPriceAmountRaw!,
+		compareToPriceCurrencyAddress: params.compareToPriceCurrencyAddress!,
+	};
+
+	return [...currencyKeys.conversion, 'compare', apiArgs] as const;
+}
+
 export function comparePricesQueryOptions(params: ComparePricesQueryOptions) {
 	const enabled = Boolean(
 		params.chainId &&
@@ -86,7 +98,7 @@ export function comparePricesQueryOptions(params: ComparePricesQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: ['currency', 'conversion', 'compare', params],
+		queryKey: getComparePricesQueryKey(params),
 		queryFn: () =>
 			fetchComparePrices({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/convertPriceToUSD.ts
+++ b/sdk/src/react/queries/convertPriceToUSD.ts
@@ -3,6 +3,7 @@ import { type Address, formatUnits } from 'viem';
 import type { SdkConfig } from '../../types';
 import {
 	type Currency,
+	currencyKeys,
 	getQueryClient,
 	type ValuesOptional,
 } from '../_internal';
@@ -62,6 +63,18 @@ export type ConvertPriceToUSDQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getConvertPriceToUSDQueryKey(
+	params: ConvertPriceToUSDQueryOptions,
+) {
+	const apiArgs = {
+		chainId: params.chainId!,
+		currencyAddress: params.currencyAddress!,
+		amountRaw: params.amountRaw!,
+	};
+
+	return [...currencyKeys.conversion, 'usd', apiArgs] as const;
+}
+
 export function convertPriceToUSDQueryOptions(
 	params: ConvertPriceToUSDQueryOptions,
 ) {
@@ -74,7 +87,7 @@ export function convertPriceToUSDQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: ['currency', 'convertPriceToUSD', params],
+		queryKey: getConvertPriceToUSDQueryKey(params),
 		queryFn: () =>
 			fetchConvertPriceToUSD({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/countItemsOrdersForCollection.ts
+++ b/sdk/src/react/queries/countItemsOrdersForCollection.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	GetCountOfAllOrdersArgs,
 	OrderSide,
@@ -40,6 +44,21 @@ export type CountItemsOrdersForCollectionQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCountItemsOrdersForCollectionQueryKey(
+	params: CountItemsOrdersForCollectionQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		side: params.side!,
+	} satisfies QueryKeyArgs<GetCountOfAllOrdersArgs>;
+
+	return [...collectionKeys.collectionItemsOrdersCount, apiArgs] as const;
+}
+
 export function countItemsOrdersForCollectionQueryOptions(
 	params: CountItemsOrdersForCollectionQueryOptions,
 ) {
@@ -52,7 +71,7 @@ export function countItemsOrdersForCollectionQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.collectionItemsOrdersCount, params],
+		queryKey: getCountItemsOrdersForCollectionQueryKey(params),
 		queryFn: () =>
 			fetchCountItemsOrdersForCollection({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/countItemsOrdersForCollection.ts
+++ b/sdk/src/react/queries/countItemsOrdersForCollection.ts
@@ -48,12 +48,9 @@ export function getCountItemsOrdersForCollectionQueryKey(
 	params: CountItemsOrdersForCollectionQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		side: params.side!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		side: params.side,
 	} satisfies QueryKeyArgs<GetCountOfAllOrdersArgs>;
 
 	return [...collectionKeys.collectionItemsOrdersCount, apiArgs] as const;

--- a/sdk/src/react/queries/countListingsForCollectible.ts
+++ b/sdk/src/react/queries/countListingsForCollectible.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	GetCountOfListingsForCollectibleArgs,
 	OrderFilter,
@@ -42,6 +46,22 @@ export type CountListingsForCollectibleQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCountListingsForCollectibleQueryKey(
+	params: CountListingsForCollectibleQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		tokenId: params.collectibleId!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetCountOfListingsForCollectibleArgs>;
+
+	return [...collectableKeys.listingsCount, apiArgs] as const;
+}
+
 export function countListingsForCollectibleQueryOptions(
 	params: CountListingsForCollectibleQueryOptions,
 ) {
@@ -54,7 +74,7 @@ export function countListingsForCollectibleQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.listingsCount, params],
+		queryKey: getCountListingsForCollectibleQueryKey(params),
 		queryFn: () =>
 			fetchCountListingsForCollectible({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/countListingsForCollectible.ts
+++ b/sdk/src/react/queries/countListingsForCollectible.ts
@@ -50,12 +50,9 @@ export function getCountListingsForCollectibleQueryKey(
 	params: CountListingsForCollectibleQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		tokenId: params.collectibleId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.collectibleId,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<GetCountOfListingsForCollectibleArgs>;
 

--- a/sdk/src/react/queries/countOfCollectables.ts
+++ b/sdk/src/react/queries/countOfCollectables.ts
@@ -63,10 +63,8 @@ export function getCountOfCollectablesQueryKey(
 ) {
 	if (params.filter && params.side) {
 		const apiArgs = {
-			// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-			chainId: String(params.chainId!),
-			// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-			contractAddress: params.collectionAddress!,
+			chainId: String(params.chainId),
+			contractAddress: params.collectionAddress,
 			filter: params.filter,
 			side: params.side,
 		} satisfies QueryKeyArgs<GetCountOfFilteredCollectiblesArgs>;
@@ -75,10 +73,8 @@ export function getCountOfCollectablesQueryKey(
 	}
 
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
 	} satisfies QueryKeyArgs<GetCountOfAllCollectiblesArgs>;
 
 	return [...collectableKeys.counts, apiArgs] as const;

--- a/sdk/src/react/queries/countOfCollectables.ts
+++ b/sdk/src/react/queries/countOfCollectables.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	CollectiblesFilter,
 	GetCountOfAllCollectiblesArgs,
@@ -54,6 +58,32 @@ export type CountOfCollectablesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCountOfCollectablesQueryKey(
+	params: CountOfCollectablesQueryOptions,
+) {
+	if (params.filter && params.side) {
+		const apiArgs = {
+			// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+			chainId: String(params.chainId!),
+			// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+			contractAddress: params.collectionAddress!,
+			filter: params.filter,
+			side: params.side,
+		} satisfies QueryKeyArgs<GetCountOfFilteredCollectiblesArgs>;
+
+		return [...collectableKeys.counts, apiArgs] as const;
+	}
+
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+	} satisfies QueryKeyArgs<GetCountOfAllCollectiblesArgs>;
+
+	return [...collectableKeys.counts, apiArgs] as const;
+}
+
 export function countOfCollectablesQueryOptions(
 	params: CountOfCollectablesQueryOptions,
 ) {
@@ -65,7 +95,7 @@ export function countOfCollectablesQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.counts, params],
+		queryKey: getCountOfCollectablesQueryKey(params),
 		queryFn: () =>
 			fetchCountOfCollectables({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/countOfPrimarySaleItems.ts
+++ b/sdk/src/react/queries/countOfPrimarySaleItems.ts
@@ -42,10 +42,8 @@ export function getCountOfPrimarySaleItemsQueryKey(
 	args: UseCountOfPrimarySaleItemsArgs,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(args.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		primarySaleContractAddress: args.primarySaleContractAddress!,
+		chainId: String(args.chainId),
+		primarySaleContractAddress: args.primarySaleContractAddress,
 		filter: args.filter,
 	} satisfies QueryKeyArgs<GetCountOfPrimarySaleItemsArgs>;
 

--- a/sdk/src/react/queries/countOfPrimarySaleItems.ts
+++ b/sdk/src/react/queries/countOfPrimarySaleItems.ts
@@ -2,9 +2,11 @@ import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
 import {
+	collectableKeys,
 	type GetCountOfPrimarySaleItemsArgs,
 	getMarketplaceClient,
 	type PrimarySaleItemsFilter,
+	type QueryKeyArgs,
 } from '../_internal';
 
 export interface UseCountOfPrimarySaleItemsArgs
@@ -36,13 +38,27 @@ export async function fetchCountOfPrimarySaleItems(
 	return data.count;
 }
 
+export function getCountOfPrimarySaleItemsQueryKey(
+	args: UseCountOfPrimarySaleItemsArgs,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(args.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		primarySaleContractAddress: args.primarySaleContractAddress!,
+		filter: args.filter,
+	} satisfies QueryKeyArgs<GetCountOfPrimarySaleItemsArgs>;
+
+	return [...collectableKeys.primarySaleItemsCount, apiArgs] as const;
+}
+
 export function countOfPrimarySaleItemsOptions(
 	args: UseCountOfPrimarySaleItemsArgs,
 	config: SdkConfig,
 ) {
 	return queryOptions({
 		enabled: args.query?.enabled ?? true,
-		queryKey: ['countOfPrimarySaleItems', args],
+		queryKey: getCountOfPrimarySaleItemsQueryKey(args),
 		queryFn: () => fetchCountOfPrimarySaleItems(args, config),
 	});
 }

--- a/sdk/src/react/queries/countOffersForCollectible.ts
+++ b/sdk/src/react/queries/countOffersForCollectible.ts
@@ -50,12 +50,9 @@ export function getCountOffersForCollectibleQueryKey(
 	params: CountOffersForCollectibleQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		tokenId: params.collectibleId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.collectibleId,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<GetCountOfOffersForCollectibleArgs>;
 

--- a/sdk/src/react/queries/countOffersForCollectible.ts
+++ b/sdk/src/react/queries/countOffersForCollectible.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	GetCountOfOffersForCollectibleArgs,
 	OrderFilter,
@@ -42,6 +46,22 @@ export type CountOffersForCollectibleQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCountOffersForCollectibleQueryKey(
+	params: CountOffersForCollectibleQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		tokenId: params.collectibleId!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetCountOfOffersForCollectibleArgs>;
+
+	return [...collectableKeys.offersCount, apiArgs] as const;
+}
+
 export function countOffersForCollectibleQueryOptions(
 	params: CountOffersForCollectibleQueryOptions,
 ) {
@@ -54,7 +74,7 @@ export function countOffersForCollectibleQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.offersCount, params],
+		queryKey: getCountOffersForCollectibleQueryKey(params),
 		queryFn: () =>
 			fetchCountOffersForCollectible({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/currency.ts
+++ b/sdk/src/react/queries/currency.ts
@@ -55,6 +55,15 @@ export type CurrencyQueryOptions = ValuesOptional<FetchCurrencyParams> & {
 	query?: StandardQueryOptions;
 };
 
+export function getCurrencyQueryKey(params: CurrencyQueryOptions) {
+	const apiArgs = {
+		chainId: String(params.chainId!),
+		currencyAddress: params.currencyAddress!,
+	};
+
+	return [...currencyKeys.details, apiArgs] as const;
+}
+
 export function currencyQueryOptions(params: CurrencyQueryOptions) {
 	const enabled = Boolean(
 		params.chainId &&
@@ -64,7 +73,7 @@ export function currencyQueryOptions(params: CurrencyQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...currencyKeys.details, params],
+		queryKey: getCurrencyQueryKey(params),
 		queryFn:
 			params.chainId && params.currencyAddress
 				? () =>

--- a/sdk/src/react/queries/filters.ts
+++ b/sdk/src/react/queries/filters.ts
@@ -113,8 +113,8 @@ export type FiltersQueryOptions = ValuesOptional<FetchFiltersParams> & {
 export function getFiltersQueryKey(params: FiltersQueryOptions) {
 	const apiArgs = {
 		chainID: String(params.chainId),
-		contractAddress: params.collectionAddress!,
-		excludeProperties: params.excludeProperties,
+		contractAddress: params.collectionAddress,
+		excludeProperties: undefined,
 		excludePropertyValues: params.excludePropertyValues,
 	} satisfies QueryKeyArgs<GetTokenMetadataPropertyFiltersArgs>;
 

--- a/sdk/src/react/queries/filters.ts
+++ b/sdk/src/react/queries/filters.ts
@@ -137,8 +137,10 @@ export function filtersQueryOptions(params: FiltersQueryOptions) {
 		queryKey: getFiltersQueryKey(params),
 		queryFn: () =>
 			fetchFilters({
-				chainId: params.chainId,
-				collectionAddress: params.collectionAddress,
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				chainId: params.chainId!,
+				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
+				collectionAddress: params.collectionAddress!,
 				showAllFilters: params.showAllFilters,
 				excludePropertyValues: params.excludePropertyValues,
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/filters.ts
+++ b/sdk/src/react/queries/filters.ts
@@ -1,10 +1,14 @@
-import type { PropertyFilter } from '@0xsequence/metadata';
+import type {
+	GetTokenMetadataPropertyFiltersArgs,
+	PropertyFilter,
+} from '@0xsequence/metadata';
 import { queryOptions } from '@tanstack/react-query';
 import { FilterCondition, type SdkConfig } from '../../types';
 import { compareAddress } from '../../utils';
 import {
 	getMetadataClient,
 	getQueryClient,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -106,6 +110,21 @@ export type FiltersQueryOptions = ValuesOptional<FetchFiltersParams> & {
 	query?: StandardQueryOptions;
 };
 
+export function getFiltersQueryKey(params: FiltersQueryOptions) {
+	const apiArgs = {
+		chainID: String(params.chainId),
+		contractAddress: params.collectionAddress!,
+		excludeProperties: params.excludeProperties,
+		excludePropertyValues: params.excludePropertyValues,
+	} satisfies QueryKeyArgs<GetTokenMetadataPropertyFiltersArgs>;
+
+	return [
+		'filters',
+		apiArgs,
+		{ showAllFilters: params.showAllFilters },
+	] as const;
+}
+
 export function filtersQueryOptions(params: FiltersQueryOptions) {
 	const enabled = Boolean(
 		params.chainId &&
@@ -115,13 +134,11 @@ export function filtersQueryOptions(params: FiltersQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: ['filters', params],
+		queryKey: getFiltersQueryKey(params),
 		queryFn: () =>
 			fetchFilters({
-				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
-				chainId: params.chainId!,
-				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined
-				collectionAddress: params.collectionAddress!,
+				chainId: params.chainId,
+				collectionAddress: params.collectionAddress,
 				showAllFilters: params.showAllFilters,
 				excludePropertyValues: params.excludePropertyValues,
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/floorOrder.ts
+++ b/sdk/src/react/queries/floorOrder.ts
@@ -4,6 +4,7 @@ import {
 	collectableKeys,
 	type GetFloorOrderArgs,
 	getMarketplaceClient,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -37,6 +38,20 @@ export type FloorOrderQueryOptions = ValuesOptional<FetchFloorOrderParams> & {
 	query?: StandardQueryOptions;
 };
 
+/**
+ * Generates the query key for floor order queries
+ * Extracts only API-relevant parameters, excluding config
+ */
+export function getFloorOrderQueryKey(params: FloorOrderQueryOptions) {
+	const apiArgs = {
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetFloorOrderArgs>;
+
+	return [...collectableKeys.floorOrders, apiArgs] as const;
+}
+
 export function floorOrderQueryOptions(params: FloorOrderQueryOptions) {
 	const enabled = Boolean(
 		params.collectionAddress &&
@@ -46,7 +61,7 @@ export function floorOrderQueryOptions(params: FloorOrderQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.floorOrders, params],
+		queryKey: getFloorOrderQueryKey(params),
 		queryFn: () =>
 			fetchFloorOrder({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/floorOrder.ts
+++ b/sdk/src/react/queries/floorOrder.ts
@@ -38,10 +38,6 @@ export type FloorOrderQueryOptions = ValuesOptional<FetchFloorOrderParams> & {
 	query?: StandardQueryOptions;
 };
 
-/**
- * Generates the query key for floor order queries
- * Extracts only API-relevant parameters, excluding config
- */
 export function getFloorOrderQueryKey(params: FloorOrderQueryOptions) {
 	const apiArgs = {
 		chainId: String(params.chainId),

--- a/sdk/src/react/queries/getCountOfFilteredOrders.ts
+++ b/sdk/src/react/queries/getCountOfFilteredOrders.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
-import { getMarketplaceClient, type ValuesOptional } from '../_internal';
+import {
+	getMarketplaceClient,
+	type QueryKeyArgs,
+	type ValuesOptional,
+} from '../_internal';
 import type {
 	GetCountOfFilteredOrdersArgs,
 	OrderSide,
@@ -40,6 +44,22 @@ export type GetCountOfFilteredOrdersQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getCountOfFilteredOrdersQueryKey(
+	params: GetCountOfFilteredOrdersQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		side: params.side!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetCountOfFilteredOrdersArgs>;
+
+	return [...collectionKeys.getCountOfFilteredOrders, apiArgs] as const;
+}
+
 export function getCountOfFilteredOrdersQueryOptions(
 	params: GetCountOfFilteredOrdersQueryOptions,
 ) {
@@ -52,7 +72,7 @@ export function getCountOfFilteredOrdersQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.getCountOfFilteredOrders, params],
+		queryKey: getCountOfFilteredOrdersQueryKey(params),
 		queryFn: () =>
 			fetchGetCountOfFilteredOrders({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/getCountOfFilteredOrders.ts
+++ b/sdk/src/react/queries/getCountOfFilteredOrders.ts
@@ -48,12 +48,9 @@ export function getCountOfFilteredOrdersQueryKey(
 	params: GetCountOfFilteredOrdersQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		side: params.side!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		side: params.side,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<GetCountOfFilteredOrdersArgs>;
 

--- a/sdk/src/react/queries/getTokenRanges.ts
+++ b/sdk/src/react/queries/getTokenRanges.ts
@@ -2,7 +2,7 @@ import type { GetTokenIDRangesReturn } from '@0xsequence/indexer';
 import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
-import { getIndexerClient, type ValuesOptional } from '../_internal';
+import { getIndexerClient, tokenKeys, type ValuesOptional } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
 
 export interface FetchGetTokenRangesParams {
@@ -37,6 +37,15 @@ export type GetTokenRangesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getTokenRangesQueryKey(params: GetTokenRangesQueryOptions) {
+	const apiArgs = {
+		chainId: params.chainId!,
+		contractAddress: params.collectionAddress!,
+	};
+
+	return [...tokenKeys.ranges, apiArgs] as const;
+}
+
 export function getTokenRangesQueryOptions(params: GetTokenRangesQueryOptions) {
 	const enabled = Boolean(
 		params.chainId &&
@@ -46,7 +55,7 @@ export function getTokenRangesQueryOptions(params: GetTokenRangesQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: ['indexer', 'tokenRanges', params],
+		queryKey: getTokenRangesQueryKey(params),
 		queryFn: () =>
 			fetchGetTokenRanges({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/highestOffer.ts
+++ b/sdk/src/react/queries/highestOffer.ts
@@ -39,15 +39,11 @@ export type HighestOfferQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
-/**
- * Generates the query key for highest offer queries
- * Extracts only API-relevant parameters, excluding config
- */
 export function getHighestOfferQueryKey(params: HighestOfferQueryOptions) {
 	const apiArgs = {
-		chainId: String(params.chainId!),
-		contractAddress: params.collectionAddress!,
-		tokenId: params.tokenId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.tokenId,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<GetCollectibleHighestOfferArgs>;
 

--- a/sdk/src/react/queries/highestOffer.ts
+++ b/sdk/src/react/queries/highestOffer.ts
@@ -4,6 +4,7 @@ import {
 	collectableKeys,
 	type GetCollectibleHighestOfferArgs,
 	getMarketplaceClient,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -38,6 +39,21 @@ export type HighestOfferQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+/**
+ * Generates the query key for highest offer queries
+ * Extracts only API-relevant parameters, excluding config
+ */
+export function getHighestOfferQueryKey(params: HighestOfferQueryOptions) {
+	const apiArgs = {
+		chainId: String(params.chainId!),
+		contractAddress: params.collectionAddress!,
+		tokenId: params.tokenId!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetCollectibleHighestOfferArgs>;
+
+	return [...collectableKeys.highestOffers, apiArgs] as const;
+}
+
 export function highestOfferQueryOptions(params: HighestOfferQueryOptions) {
 	const enabled = Boolean(
 		params.collectionAddress &&
@@ -48,7 +64,7 @@ export function highestOfferQueryOptions(params: HighestOfferQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.highestOffers, params],
+		queryKey: getHighestOfferQueryKey(params),
 		queryFn: () =>
 			fetchHighestOffer({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listBalances.ts
+++ b/sdk/src/react/queries/listBalances.ts
@@ -55,6 +55,21 @@ export async function fetchBalances(
 	});
 }
 
+export function getListBalancesQueryKey(args: UseListBalancesArgs) {
+	const apiArgs = {
+		chainId: args.chainId,
+		accountAddress: args.accountAddress,
+		contractAddress: args.contractAddress,
+		tokenID: args.tokenId,
+		includeMetadata: args.includeMetadata,
+		metadataOptions: args.metadataOptions,
+		includeCollectionTokens: args.includeCollectionTokens,
+		isLaos721: args.isLaos721,
+	};
+
+	return [...balanceQueries.lists, apiArgs] as const;
+}
+
 /**
  * Creates a tanstack infinite query options object for the balances query
  *
@@ -68,7 +83,7 @@ export function listBalancesOptions(
 ) {
 	return infiniteQueryOptions({
 		...args.query,
-		queryKey: [...balanceQueries.lists, args, config],
+		queryKey: getListBalancesQueryKey(args),
 		queryFn: ({ pageParam }) => fetchBalances(args, config, pageParam),
 		initialPageParam: { page: 1, pageSize: 30 } as Page,
 		getNextPageParam: (lastPage) => lastPage.page.after,

--- a/sdk/src/react/queries/listCollectibleActivities.ts
+++ b/sdk/src/react/queries/listCollectibleActivities.ts
@@ -68,6 +68,7 @@ export type ListCollectibleActivitiesQueryOptions =
 export function getListCollectibleActivitiesQueryKey(
 	params: ListCollectibleActivitiesQueryOptions,
 ) {
+	// TODO: Do we actually want to do the page like this?
 	const page =
 		params.page || params.pageSize || params.sort
 			? {

--- a/sdk/src/react/queries/listCollectibleActivities.ts
+++ b/sdk/src/react/queries/listCollectibleActivities.ts
@@ -78,12 +78,9 @@ export function getListCollectibleActivitiesQueryKey(
 			: undefined;
 
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		tokenId: params.tokenId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.tokenId,
 		page: page,
 	} satisfies QueryKeyArgs<ListCollectibleActivitiesArgs>;
 

--- a/sdk/src/react/queries/listCollectibleActivities.ts
+++ b/sdk/src/react/queries/listCollectibleActivities.ts
@@ -4,6 +4,7 @@ import type { Page, SdkConfig } from '../../types';
 import type {
 	ListCollectibleActivitiesArgs,
 	ListCollectibleActivitiesReturn,
+	QueryKeyArgs,
 	SortBy,
 	ValuesOptional,
 } from '../_internal';
@@ -64,6 +65,31 @@ export type ListCollectibleActivitiesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListCollectibleActivitiesQueryKey(
+	params: ListCollectibleActivitiesQueryOptions,
+) {
+	const page =
+		params.page || params.pageSize || params.sort
+			? {
+					page: params.page ?? 1,
+					pageSize: params.pageSize ?? 10,
+					sort: params.sort,
+				}
+			: undefined;
+
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		tokenId: params.tokenId!,
+		page: page,
+	} satisfies QueryKeyArgs<ListCollectibleActivitiesArgs>;
+
+	return [...collectableKeys.collectibleActivities, apiArgs] as const;
+}
+
 export function listCollectibleActivitiesQueryOptions(
 	params: ListCollectibleActivitiesQueryOptions,
 ) {
@@ -76,7 +102,7 @@ export function listCollectibleActivitiesQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.collectibleActivities, params],
+		queryKey: getListCollectibleActivitiesQueryKey(params),
 		queryFn: () =>
 			fetchListCollectibleActivities({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listCollectibles.ts
+++ b/sdk/src/react/queries/listCollectibles.ts
@@ -116,11 +116,8 @@ export function getListCollectiblesQueryKey(
 	params: ListCollectiblesQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
 		side: params.side!,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<Omit<ListCollectiblesArgs, 'page'>>;

--- a/sdk/src/react/queries/listCollectibles.ts
+++ b/sdk/src/react/queries/listCollectibles.ts
@@ -6,6 +6,7 @@ import { compareAddress } from '../../utils';
 import type {
 	ListCollectiblesArgs,
 	ListCollectiblesReturn,
+	QueryKeyArgs,
 	ValuesOptional,
 } from '../_internal';
 import {
@@ -111,6 +112,22 @@ export type ListCollectiblesQueryOptions =
 		query?: StandardInfiniteQueryOptions;
 	};
 
+export function getListCollectiblesQueryKey(
+	params: ListCollectiblesQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		side: params.side!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<Omit<ListCollectiblesArgs, 'page'>>;
+
+	return [...collectableKeys.lists, apiArgs] as const;
+}
+
 export function listCollectiblesQueryOptions(
 	params: ListCollectiblesQueryOptions,
 ) {
@@ -123,7 +140,7 @@ export function listCollectiblesQueryOptions(
 	);
 
 	return infiniteQueryOptions({
-		queryKey: [...collectableKeys.lists, params],
+		queryKey: getListCollectiblesQueryKey(params),
 		queryFn: async ({ pageParam }) => {
 			return fetchListCollectibles(
 				{

--- a/sdk/src/react/queries/listCollectiblesPaginated.ts
+++ b/sdk/src/react/queries/listCollectiblesPaginated.ts
@@ -4,6 +4,7 @@ import type { Page, SdkConfig } from '../../types';
 import type {
 	ListCollectiblesArgs,
 	ListCollectiblesReturn,
+	QueryKeyArgs,
 	ValuesOptional,
 } from '../_internal';
 import { collectableKeys, getMarketplaceClient } from '../_internal';
@@ -54,6 +55,25 @@ export type ListCollectiblesPaginatedQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListCollectiblesPaginatedQueryKey(
+	params: ListCollectiblesPaginatedQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		side: params.side!,
+		filter: params.filter,
+		page: params.page
+			? { page: params.page, pageSize: params.pageSize ?? 30 }
+			: undefined,
+	} satisfies QueryKeyArgs<ListCollectiblesArgs>;
+
+	return [...collectableKeys.lists, 'paginated', apiArgs] as const;
+}
+
 export function listCollectiblesPaginatedQueryOptions(
 	params: ListCollectiblesPaginatedQueryOptions,
 ) {
@@ -66,7 +86,7 @@ export function listCollectiblesPaginatedQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.lists, 'paginated', params],
+		queryKey: getListCollectiblesPaginatedQueryKey(params),
 		queryFn: () =>
 			fetchListCollectiblesPaginated({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listCollectiblesPaginated.ts
+++ b/sdk/src/react/queries/listCollectiblesPaginated.ts
@@ -59,12 +59,9 @@ export function getListCollectiblesPaginatedQueryKey(
 	params: ListCollectiblesPaginatedQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		side: params.side!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		side: params.side,
 		filter: params.filter,
 		page: params.page
 			? { page: params.page, pageSize: params.pageSize ?? 30 }

--- a/sdk/src/react/queries/listCollectionActivities.ts
+++ b/sdk/src/react/queries/listCollectionActivities.ts
@@ -79,10 +79,8 @@ export function getListCollectionActivitiesQueryKey(
 			: undefined;
 
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
 		page: page,
 	} satisfies QueryKeyArgs<ListCollectionActivitiesArgs>;
 

--- a/sdk/src/react/queries/listCollectionActivities.ts
+++ b/sdk/src/react/queries/listCollectionActivities.ts
@@ -4,6 +4,7 @@ import type { Page, SdkConfig } from '../../types';
 import type {
 	ListCollectionActivitiesArgs,
 	ListCollectionActivitiesReturn,
+	QueryKeyArgs,
 	SortBy,
 	ValuesOptional,
 } from '../_internal';
@@ -65,6 +66,29 @@ export type ListCollectionActivitiesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListCollectionActivitiesQueryKey(
+	params: ListCollectionActivitiesQueryOptions,
+) {
+	const page =
+		params.page || params.pageSize || params.sort
+			? {
+					page: params.page ?? 1,
+					pageSize: params.pageSize ?? 10,
+					sort: params.sort,
+				}
+			: undefined;
+
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		page: page,
+	} satisfies QueryKeyArgs<ListCollectionActivitiesArgs>;
+
+	return [...collectionKeys.collectionActivities, apiArgs] as const;
+}
+
 export function listCollectionActivitiesQueryOptions(
 	params: ListCollectionActivitiesQueryOptions,
 ) {
@@ -76,7 +100,7 @@ export function listCollectionActivitiesQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.collectionActivities, params],
+		queryKey: getListCollectionActivitiesQueryKey(params),
 		queryFn: () =>
 			fetchListCollectionActivities({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listCollections.ts
+++ b/sdk/src/react/queries/listCollections.ts
@@ -113,6 +113,17 @@ export type ListCollectionsQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListCollectionsQueryKey(
+	params: ListCollectionsQueryOptions,
+) {
+	const queryKeyParams = {
+		cardType: params.cardType,
+		marketplaceConfig: params.marketplaceConfig,
+	} as const;
+
+	return [...collectionKeys.list, queryKeyParams] as const;
+}
+
 export function listCollectionsQueryOptions(
 	params: ListCollectionsQueryOptions,
 ) {
@@ -123,7 +134,7 @@ export function listCollectionsQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectionKeys.list, params],
+		queryKey: getListCollectionsQueryKey(params),
 		queryFn: enabled
 			? () =>
 					fetchListCollections({

--- a/sdk/src/react/queries/listItemsOrdersForCollection.ts
+++ b/sdk/src/react/queries/listItemsOrdersForCollection.ts
@@ -4,6 +4,7 @@ import type { Page, SdkConfig } from '../../types';
 import type {
 	ListOrdersWithCollectiblesArgs,
 	ListOrdersWithCollectiblesReturn,
+	QueryKeyArgs,
 	ValuesOptional,
 } from '../_internal';
 import { collectionKeys, getMarketplaceClient } from '../_internal';
@@ -38,6 +39,19 @@ export type ListItemsOrdersForCollectionQueryOptions =
 		query?: StandardInfiniteQueryOptions;
 	};
 
+export function getListItemsOrdersForCollectionQueryKey(
+	params: ListItemsOrdersForCollectionQueryOptions,
+) {
+	const apiArgs = {
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		side: params.side,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<Omit<ListOrdersWithCollectiblesArgs, 'page'>>;
+
+	return [...collectionKeys.collectionItemsOrders, apiArgs] as const;
+}
+
 export function listItemsOrdersForCollectionQueryOptions(
 	params: ListItemsOrdersForCollectionQueryOptions,
 ) {
@@ -50,7 +64,7 @@ export function listItemsOrdersForCollectionQueryOptions(
 	);
 
 	return infiniteQueryOptions({
-		queryKey: [...collectionKeys.collectionItemsOrders, params],
+		queryKey: getListItemsOrdersForCollectionQueryKey(params),
 		queryFn: async ({ pageParam }) => {
 			return fetchListItemsOrdersForCollection(
 				{

--- a/sdk/src/react/queries/listListingsForCollectible.ts
+++ b/sdk/src/react/queries/listListingsForCollectible.ts
@@ -4,6 +4,7 @@ import type { SdkConfig } from '../../types';
 import type {
 	ListCollectibleListingsArgs,
 	ListCollectibleListingsReturn,
+	QueryKeyArgs,
 	ValuesOptional,
 } from '../_internal';
 import { collectableKeys, getMarketplaceClient } from '../_internal';
@@ -50,6 +51,27 @@ export type ListListingsForCollectibleQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+/**
+ * Generates the query key for list listings for collectible queries
+ * Extracts only API-relevant parameters, excluding config
+ */
+export function getListListingsForCollectibleQueryKey(
+	params: ListListingsForCollectibleQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		tokenId: params.collectibleId!,
+		filter: params.filter,
+		page: params.page,
+	} satisfies QueryKeyArgs<ListCollectibleListingsArgs>;
+
+	return [...collectableKeys.listings, apiArgs] as const;
+}
+
 export function listListingsForCollectibleQueryOptions(
 	params: ListListingsForCollectibleQueryOptions,
 ) {
@@ -62,7 +84,7 @@ export function listListingsForCollectibleQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.listings, params],
+		queryKey: getListListingsForCollectibleQueryKey(params),
 		queryFn: () =>
 			fetchListListingsForCollectible({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listListingsForCollectible.ts
+++ b/sdk/src/react/queries/listListingsForCollectible.ts
@@ -59,12 +59,9 @@ export function getListListingsForCollectibleQueryKey(
 	params: ListListingsForCollectibleQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		tokenId: params.collectibleId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.collectibleId,
 		filter: params.filter,
 		page: params.page,
 	} satisfies QueryKeyArgs<ListCollectibleListingsArgs>;

--- a/sdk/src/react/queries/listListingsForCollectible.ts
+++ b/sdk/src/react/queries/listListingsForCollectible.ts
@@ -51,10 +51,6 @@ export type ListListingsForCollectibleQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
-/**
- * Generates the query key for list listings for collectible queries
- * Extracts only API-relevant parameters, excluding config
- */
 export function getListListingsForCollectibleQueryKey(
 	params: ListListingsForCollectibleQueryOptions,
 ) {

--- a/sdk/src/react/queries/listOffersForCollectible.ts
+++ b/sdk/src/react/queries/listOffersForCollectible.ts
@@ -73,12 +73,9 @@ export function getListOffersForCollectibleQueryKey(
 	params: ListOffersForCollectibleQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
-		chainId: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
-		contractAddress: params.collectionAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
-		tokenId: params.collectibleId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.collectibleId,
 		filter: params.filter,
 		page: params.page,
 	} satisfies QueryKeyArgs<ListOffersForCollectibleArgs>;

--- a/sdk/src/react/queries/listOffersForCollectible.ts
+++ b/sdk/src/react/queries/listOffersForCollectible.ts
@@ -5,6 +5,7 @@ import type {
 	ListCollectibleOffersReturn,
 	ListOffersForCollectibleArgs,
 	Page,
+	QueryKeyArgs,
 	SortBy,
 	ValuesOptional,
 } from '../_internal';
@@ -68,6 +69,23 @@ export type ListOffersForCollectibleQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListOffersForCollectibleQueryKey(
+	params: ListOffersForCollectibleQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
+		chainId: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
+		contractAddress: params.collectionAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Query key can be generated with undefined values for disabled queries
+		tokenId: params.collectibleId!,
+		filter: params.filter,
+		page: params.page,
+	} satisfies QueryKeyArgs<ListOffersForCollectibleArgs>;
+
+	return [...collectableKeys.offers, apiArgs] as const;
+}
+
 export function listOffersForCollectibleQueryOptions(
 	params: ListOffersForCollectibleQueryOptions,
 ) {
@@ -80,7 +98,7 @@ export function listOffersForCollectibleQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.offers, params],
+		queryKey: getListOffersForCollectibleQueryKey(params),
 		queryFn: () =>
 			fetchListOffersForCollectible({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listTokenMetadata.ts
+++ b/sdk/src/react/queries/listTokenMetadata.ts
@@ -1,7 +1,9 @@
+import type { GetTokenMetadataArgs } from '@0xsequence/metadata';
 import { queryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
 import {
 	getMetadataClient,
+	type QueryKeyArgs,
 	tokenKeys,
 	type ValuesOptional,
 } from '../_internal';
@@ -37,6 +39,21 @@ export type ListTokenMetadataQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListTokenMetadataQueryKey(
+	params: ListTokenMetadataQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainID: String(params.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		contractAddress: params.contractAddress!,
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		tokenIDs: params.tokenIds!,
+	} satisfies QueryKeyArgs<GetTokenMetadataArgs>;
+
+	return [...tokenKeys.metadata, apiArgs] as const;
+}
+
 export function listTokenMetadataQueryOptions(
 	params: ListTokenMetadataQueryOptions,
 ) {
@@ -49,7 +66,7 @@ export function listTokenMetadataQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...tokenKeys.metadata, params],
+		queryKey: getListTokenMetadataQueryKey(params),
 		queryFn: () =>
 			fetchListTokenMetadata({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/listTokenMetadata.ts
+++ b/sdk/src/react/queries/listTokenMetadata.ts
@@ -43,12 +43,9 @@ export function getListTokenMetadataQueryKey(
 	params: ListTokenMetadataQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainID: String(params.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		contractAddress: params.contractAddress!,
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		tokenIDs: params.tokenIds!,
+		chainID: String(params.chainId),
+		contractAddress: params.contractAddress,
+		tokenIDs: params.tokenIds,
 	} satisfies QueryKeyArgs<GetTokenMetadataArgs>;
 
 	return [...tokenKeys.metadata, apiArgs] as const;

--- a/sdk/src/react/queries/lowestListing.ts
+++ b/sdk/src/react/queries/lowestListing.ts
@@ -42,15 +42,11 @@ export type LowestListingQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
-/**
- * Generates the query key for lowest listing queries
- * Extracts only API-relevant parameters, excluding config
- */
 export function getLowestListingQueryKey(params: LowestListingQueryOptions) {
 	const apiArgs = {
-		chainId: String(params.chainId!),
-		contractAddress: params.collectionAddress!,
-		tokenId: params.tokenId!,
+		chainId: String(params.chainId),
+		contractAddress: params.collectionAddress,
+		tokenId: params.tokenId,
 		filter: params.filter,
 	} satisfies QueryKeyArgs<GetCollectibleLowestListingArgs>;
 

--- a/sdk/src/react/queries/lowestListing.ts
+++ b/sdk/src/react/queries/lowestListing.ts
@@ -5,6 +5,7 @@ import {
 	type GetCollectibleLowestListingArgs,
 	type GetCollectibleLowestListingReturn,
 	getMarketplaceClient,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -41,6 +42,21 @@ export type LowestListingQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+/**
+ * Generates the query key for lowest listing queries
+ * Extracts only API-relevant parameters, excluding config
+ */
+export function getLowestListingQueryKey(params: LowestListingQueryOptions) {
+	const apiArgs = {
+		chainId: String(params.chainId!),
+		contractAddress: params.collectionAddress!,
+		tokenId: params.tokenId!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<GetCollectibleLowestListingArgs>;
+
+	return [...collectableKeys.lowestListings, apiArgs] as const;
+}
+
 export function lowestListingQueryOptions(params: LowestListingQueryOptions) {
 	const enabled = Boolean(
 		params.collectionAddress &&
@@ -51,7 +67,7 @@ export function lowestListingQueryOptions(params: LowestListingQueryOptions) {
 	);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.lowestListings, params],
+		queryKey: getLowestListingQueryKey(params),
 		queryFn: () =>
 			fetchLowestListing({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/marketCurrencies.ts
+++ b/sdk/src/react/queries/marketCurrencies.ts
@@ -6,6 +6,8 @@ import {
 	currencyKeys,
 	getMarketplaceClient,
 	getQueryClient,
+	type ListCurrenciesArgs,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -70,6 +72,23 @@ export type MarketCurrenciesQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getMarketCurrenciesQueryKey(
+	params: MarketCurrenciesQueryOptions,
+) {
+	const apiArgs = {
+		chainId: String(params.chainId),
+	} satisfies QueryKeyArgs<ListCurrenciesArgs>;
+
+	return [
+		...currencyKeys.lists,
+		apiArgs,
+		{
+			includeNativeCurrency: params.includeNativeCurrency,
+			collectionAddress: params.collectionAddress,
+		},
+	] as const;
+}
+
 export function marketCurrenciesQueryOptions(
 	params: MarketCurrenciesQueryOptions,
 ) {
@@ -78,7 +97,7 @@ export function marketCurrenciesQueryOptions(
 	);
 
 	return queryOptions({
-		queryKey: [...currencyKeys.lists, params],
+		queryKey: getMarketCurrenciesQueryKey(params),
 		queryFn: () =>
 			fetchMarketCurrencies({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/primarySaleItems.ts
+++ b/sdk/src/react/queries/primarySaleItems.ts
@@ -2,11 +2,13 @@ import { infiniteQueryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
 import {
+	collectableKeys,
 	getMarketplaceClient,
 	type ListPrimarySaleItemsArgs,
 	type ListPrimarySaleItemsReturn,
 	type Page,
 	type PrimarySaleItemsFilter,
+	type QueryKeyArgs,
 	type ValuesOptional,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
@@ -42,6 +44,18 @@ export type ListPrimarySaleItemsQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getListPrimarySaleItemsQueryKey(
+	params: ListPrimarySaleItemsQueryOptions,
+) {
+	const apiArgs = {
+		chainId: String(params.chainId),
+		primarySaleContractAddress: params.primarySaleContractAddress,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<Omit<ListPrimarySaleItemsArgs, 'page'>>;
+
+	return [...collectableKeys.listPrimarySaleItems, apiArgs] as const;
+}
+
 export const listPrimarySaleItemsQueryOptions = (
 	params: ListPrimarySaleItemsQueryOptions,
 ) => {
@@ -56,7 +70,7 @@ export const listPrimarySaleItemsQueryOptions = (
 	const initialPage: PageParam = params.page || { page: 1, pageSize: 30 };
 
 	return infiniteQueryOptions({
-		queryKey: ['listPrimarySaleItems', params],
+		queryKey: getListPrimarySaleItemsQueryKey(params),
 		queryFn: async ({ pageParam }) => {
 			return fetchPrimarySaleItems({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/primarySaleItemsCount.ts
+++ b/sdk/src/react/queries/primarySaleItemsCount.ts
@@ -2,9 +2,12 @@ import { queryOptions } from '@tanstack/react-query';
 import type { Address } from 'viem';
 import type { SdkConfig } from '../../types';
 import {
+	collectableKeys,
+	type GetCountOfPrimarySaleItemsArgs,
 	type GetCountOfPrimarySaleItemsReturn,
 	getMarketplaceClient,
 	type PrimarySaleItemsFilter,
+	type QueryKeyArgs,
 } from '../_internal';
 import type { StandardQueryOptions } from '../types/query';
 
@@ -36,6 +39,20 @@ export type PrimarySaleItemsCountQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getPrimarySaleItemsCountQueryKey(
+	args: PrimarySaleItemsCountQueryOptions,
+) {
+	const apiArgs = {
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		chainId: String(args.chainId!),
+		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
+		primarySaleContractAddress: args.primarySaleContractAddress!,
+		filter: args.filter,
+	} satisfies QueryKeyArgs<GetCountOfPrimarySaleItemsArgs>;
+
+	return [...collectableKeys.primarySaleItemsCount, apiArgs] as const;
+}
+
 export const primarySaleItemsCountQueryOptions = (
 	args: PrimarySaleItemsCountQueryOptions,
 ) => {
@@ -47,7 +64,7 @@ export const primarySaleItemsCountQueryOptions = (
 	);
 
 	return queryOptions({
-		queryKey: ['primarySaleItemsCount', args],
+		queryKey: getPrimarySaleItemsCountQueryKey(args),
 		queryFn: () =>
 			fetchPrimarySaleItemsCount({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/primarySaleItemsCount.ts
+++ b/sdk/src/react/queries/primarySaleItemsCount.ts
@@ -43,10 +43,8 @@ export function getPrimarySaleItemsCountQueryKey(
 	args: PrimarySaleItemsCountQueryOptions,
 ) {
 	const apiArgs = {
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		chainId: String(args.chainId!),
-		// biome-ignore lint/style/noNonNullAssertion: Params are validated before query key generation
-		primarySaleContractAddress: args.primarySaleContractAddress!,
+		chainId: String(args.chainId),
+		primarySaleContractAddress: args.primarySaleContractAddress,
 		filter: args.filter,
 	} satisfies QueryKeyArgs<GetCountOfPrimarySaleItemsArgs>;
 

--- a/sdk/src/react/queries/searchTokenMetadata.ts
+++ b/sdk/src/react/queries/searchTokenMetadata.ts
@@ -1,12 +1,14 @@
 import type {
 	Filter,
 	Page,
+	SearchTokenMetadataArgs,
 	SearchTokenMetadataReturn,
 } from '@0xsequence/metadata';
 import { infiniteQueryOptions } from '@tanstack/react-query';
 import type { SdkConfig } from '../../types';
 import {
 	getMetadataClient,
+	type QueryKeyArgs,
 	tokenKeys,
 	type ValuesOptional,
 } from '../_internal';
@@ -47,6 +49,18 @@ export type SearchTokenMetadataQueryOptions =
 		query?: StandardQueryOptions;
 	};
 
+export function getSearchTokenMetadataQueryKey(
+	params: SearchTokenMetadataQueryOptions,
+) {
+	const apiArgs = {
+		chainID: String(params.chainId!),
+		contractAddress: params.collectionAddress!,
+		filter: params.filter,
+	} satisfies QueryKeyArgs<Omit<SearchTokenMetadataArgs, 'page'>>;
+
+	return [...tokenKeys.metadata, 'search', apiArgs] as const;
+}
+
 export function searchTokenMetadataQueryOptions(
 	params: SearchTokenMetadataQueryOptions,
 ) {
@@ -60,7 +74,7 @@ export function searchTokenMetadataQueryOptions(
 	const initialPageParam = { page: 1, pageSize: 30 };
 
 	return infiniteQueryOptions({
-		queryKey: [...tokenKeys.metadata, 'search', params],
+		queryKey: getSearchTokenMetadataQueryKey(params),
 		queryFn: ({ pageParam = initialPageParam }) =>
 			fetchSearchTokenMetadata({
 				// biome-ignore lint/style/noNonNullAssertion: The enabled check above ensures these are not undefined

--- a/sdk/src/react/queries/tokenBalances.ts
+++ b/sdk/src/react/queries/tokenBalances.ts
@@ -52,6 +52,24 @@ export async function fetchTokenBalances(
 		.then((res) => res.balances || []);
 }
 
+export function getTokenBalancesQueryKey(args: UseTokenBalancesArgs) {
+	const apiArgs = {
+		chainId: args.chainId,
+		accountAddress: args.userAddress,
+		contractAddress: args.collectionAddress,
+		includeMetadata: args.includeMetadata,
+		metadataOptions: args.userAddress
+			? {
+					verifiedOnly: true,
+					includeContracts: [args.collectionAddress],
+				}
+			: undefined,
+		isLaos721: args.isLaos721,
+	};
+
+	return [...collectableKeys.userBalances, apiArgs] as const;
+}
+
 /**
  * Creates a tanstack query options object for the token balances query
  *
@@ -69,7 +87,7 @@ export function tokenBalancesOptions(
 		(args.query?.enabled ?? true);
 
 	return queryOptions({
-		queryKey: [...collectableKeys.userBalances, args],
+		queryKey: getTokenBalancesQueryKey(args),
 		queryFn: enabled
 			? () =>
 					fetchTokenBalances(

--- a/sdk/src/react/queries/tokenSupplies.ts
+++ b/sdk/src/react/queries/tokenSupplies.ts
@@ -65,6 +65,18 @@ export type TokenSuppliesQueryOptions =
 		query?: StandardInfiniteQueryOptions;
 	};
 
+export function getTokenSuppliesQueryKey(params: TokenSuppliesQueryOptions) {
+	const apiArgs = {
+		chainId: params.chainId!,
+		contractAddress: params.collectionAddress!,
+		includeMetadata: params.includeMetadata,
+		metadataOptions: params.metadataOptions,
+		isLaos721: params.isLaos721,
+	};
+
+	return [...tokenKeys.supplies, apiArgs] as const;
+}
+
 export function tokenSuppliesQueryOptions(params: TokenSuppliesQueryOptions) {
 	const enabled = Boolean(
 		params.chainId &&
@@ -90,7 +102,7 @@ export function tokenSuppliesQueryOptions(params: TokenSuppliesQueryOptions) {
 		});
 
 	return infiniteQueryOptions({
-		queryKey: [...tokenKeys.supplies, params],
+		queryKey: getTokenSuppliesQueryKey(params),
 		queryFn,
 		initialPageParam,
 		getNextPageParam: (lastPage) =>

--- a/sdk/src/react/utils/waitForTransactionReceipt.ts
+++ b/sdk/src/react/utils/waitForTransactionReceipt.ts
@@ -1,49 +1,43 @@
 import type { TransactionReceipt } from '@0xsequence/indexer';
-import {
-	type Hex,
-	TransactionReceiptNotFoundError,
-	WaitForTransactionReceiptTimeoutError,
-} from 'viem';
+import { type Hex, TransactionReceiptNotFoundError } from 'viem';
 import type { SdkConfig } from '../../types';
 import { getIndexerClient } from '../_internal/api';
 
-const ONE_MIN = 60 * 1000;
-const THREE_MIN = 3 * ONE_MIN;
+const MAX_RETRIES = 3;
+const MAX_BLOCK_WAIT = 30;
 
 export const waitForTransactionReceipt = async ({
 	txHash,
 	chainId,
 	sdkConfig,
-	timeout = THREE_MIN,
+	maxBlockWait = MAX_BLOCK_WAIT,
 }: {
 	txHash: Hex;
 	chainId: number;
 	sdkConfig: SdkConfig;
-	timeout?: number;
+	maxBlockWait?: number;
 }): Promise<TransactionReceipt> => {
 	const indexer = getIndexerClient(chainId, sdkConfig);
-	return Promise.race([
-		new Promise<TransactionReceipt>((resolve, reject) => {
-			indexer.subscribeReceipts(
-				{
-					filter: {
-						txnHash: txHash,
-					},
-				},
-				{
-					onMessage: ({ receipt }) => {
-						resolve(receipt);
-					},
-					onError: () => {
-						reject(TransactionReceiptNotFoundError);
-					},
-				},
+	let retries = 0;
+
+	while (retries < MAX_RETRIES) {
+		try {
+			const result = await indexer.fetchTransactionReceipt({
+				txnHash: txHash,
+				maxBlockWait,
+			});
+			return result.receipt;
+		} catch (error) {
+			retries++;
+			console.error(
+				`Failed to fetch transaction receipt (attempt ${retries}/${MAX_RETRIES}):`,
+				error,
 			);
-		}),
-		new Promise<TransactionReceipt>((_, reject) => {
-			setTimeout(() => {
-				reject(WaitForTransactionReceiptTimeoutError);
-			}, timeout);
-		}),
-	]);
+			if (retries >= MAX_RETRIES) {
+				throw TransactionReceiptNotFoundError;
+			}
+		}
+	}
+
+	throw TransactionReceiptNotFoundError;
 };


### PR DESCRIPTION
Adds a new function to every fetching hook that bases the query key on the arguments to the endpoint and not the params to the hook