### PR TITLE
fix: handle bundled buy totals in buy modal

### DIFF
--- a/sdk/src/react/ui/modals/BuyModal/hooks/useExecuteBundledTransactions.ts
+++ b/sdk/src/react/ui/modals/BuyModal/hooks/useExecuteBundledTransactions.ts
@@ -5,7 +5,6 @@ import type { Hex } from 'viem';
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi';
 import { useConfig } from '../../../..';
 import { getIndexerClient, type Step } from '../../../../_internal';
-import { useBuyModalData } from './useBuyModalData';
 
 // https://github.com/0xsequence/web-sdk/blob/620b6fe7681ae49efd4eb3fa7607ef01dd7ede54/packages/connect/src/utils/transactions.ts#L11-L19
 class FeeOptionInsufficientFundsError extends Error {
@@ -21,13 +20,11 @@ class FeeOptionInsufficientFundsError extends Error {
 type UseExecuteBundledTransactions = {
 	chainId: number;
 	approvalStep?: Step;
-	priceAmount: bigint;
 };
 
 const useExecuteBundledTransactions = ({
 	chainId,
 	approvalStep,
-	priceAmount,
 }: UseExecuteBundledTransactions) => {
 	const config = useConfig();
 	const [isExecuting, setIsExecuting] = useState(false);
@@ -36,16 +33,12 @@ const useExecuteBundledTransactions = ({
 	const { data: walletClient } = useWalletClient();
 	const indexerClient = getIndexerClient(chainId, config);
 
-	const { collection, currency } = useBuyModalData();
-
 	const isReady =
 		!!address &&
 		!!publicClient &&
 		!!walletClient &&
 		!!indexerClient &&
-		!!connector &&
-		!!collection?.address &&
-		priceAmount != null;
+		!!connector;
 
 	const executeBundledTransactions = async ({
 		step,
@@ -79,28 +72,22 @@ const useExecuteBundledTransactions = ({
 				throw new Error('Connector not found');
 			}
 
-			if (!collection?.address) {
-				throw new Error('Collection address not found');
-			}
+			const buildTransaction = (step: Step) => {
+				const value = step.value ? BigInt(step.value) : 0n;
 
-			if (priceAmount == null) {
-				throw new Error('Price amount not found');
-			}
+				return {
+					to: step.to,
+					data: step.data as Hex,
+					chainId,
+					...(value > 0n ? { value } : {}),
+				};
+			};
 
 			const approvalData = approvalStep
-				? {
-						to: approvalStep.to,
-						data: approvalStep.data as Hex,
-						chainId,
-					}
+				? buildTransaction(approvalStep)
 				: undefined;
 
-			const transactionData = {
-				to: step.to,
-				data: step.data as Hex,
-				chainId,
-				...(currency?.nativeCurrency ? { value: priceAmount } : {}),
-			};
+			const transactionData = buildTransaction(step);
 
 			const transactions = [
 				...(approvalData ? [approvalData] : []),

--- a/sdk/src/react/ui/modals/BuyModal/internal/cryptoPaymentModalContext.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/internal/cryptoPaymentModalContext.tsx
@@ -90,7 +90,7 @@ const toErrorWithDetails = (error: unknown): Error => {
 			try {
 				message = JSON.stringify(errorLike);
 			} catch {
-				message = String(error);
+				message = 'An unexpected error occurred.';
 			}
 		}
 

--- a/sdk/src/react/ui/modals/BuyModal/internal/cryptoPaymentModalContext.tsx
+++ b/sdk/src/react/ui/modals/BuyModal/internal/cryptoPaymentModalContext.tsx
@@ -2,8 +2,9 @@ import type { Address, Hash } from '@0xsequence/api-client';
 import { ChevronLeftIcon, Text } from '@0xsequence/design-system';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import type { Hex } from 'viem';
+import { zeroAddress, type Hex } from 'viem';
 import { useSendTransaction } from 'wagmi';
+import { getErrorMessage } from '../../../../../utils/getErrorMessage';
 import { formatPrice } from '../../../../../utils/price';
 import { type Step, StepType } from '../../../../_internal';
 import { useConnectorMetadata } from '../../../../hooks';
@@ -74,6 +75,31 @@ type CryptoPaymentModalReturn = {
 	};
 };
 
+const toErrorWithDetails = (error: unknown): Error => {
+	if (error instanceof Error) {
+		return error;
+	}
+
+	if (typeof error === 'object' && error !== null) {
+		const errorLike = error as Record<string, unknown>;
+		let message = 'An unexpected error occurred.';
+
+		if (typeof errorLike.message === 'string') {
+			message = errorLike.message;
+		} else {
+			try {
+				message = JSON.stringify(errorLike);
+			} catch {
+				message = String(error);
+			}
+		}
+
+		return Object.assign(new Error(message), errorLike);
+	}
+
+	return new Error(String(error));
+};
+
 export function useCryptoPaymentModalContext({
 	chainId,
 	steps,
@@ -114,11 +140,16 @@ export function useCryptoPaymentModalContext({
 	const priceCurrencyAddress = isMarket
 		? marketOrder?.priceCurrencyAddress
 		: (primarySaleItem?.currencyAddress as Address);
+	const listedPriceAmount = BigInt(priceAmount || 0);
+	const buyStepPriceAmount = buyStep.price ? BigInt(buyStep.price) : listedPriceAmount;
+	const buyStepValue = buyStep.value ? BigInt(buyStep.value) : buyStepPriceAmount;
+	const requiredBalance =
+		priceCurrencyAddress === zeroAddress ? buyStepValue : buyStepPriceAmount;
 	const isAnyTransactionPending = isApproving || isExecuting;
 
 	const { data, isLoading: isLoadingBalance } = useHasSufficientBalance({
 		chainId,
-		value: BigInt(priceAmount || 0),
+		value: requiredBalance,
 		tokenAddress: priceCurrencyAddress as Address,
 	});
 
@@ -136,7 +167,6 @@ export function useCryptoPaymentModalContext({
 	} = useExecuteBundledTransactions({
 		chainId,
 		approvalStep,
-		priceAmount: BigInt(priceAmount || 0),
 	});
 
 	const waas = useSelectWaasFeeOptionsStore();
@@ -197,12 +227,10 @@ export function useCryptoPaymentModalContext({
 			await executeTransaction(approvalStep);
 			setApprovalStep(undefined);
 		} catch (error) {
-			const errorObj =
-				error instanceof Error ? error : new Error(String(error));
+			const errorObj = toErrorWithDetails(error);
 			setError({
 				title: 'Approval failed',
-				message:
-					errorObj.message || 'Failed to approve token. Please try again.',
+				message: getErrorMessage(errorObj),
 				details: errorObj,
 			});
 			console.error('Approval transaction failed:', error);
@@ -224,7 +252,7 @@ export function useCryptoPaymentModalContext({
 	const handleTransactionFailed = (error: Error) => {
 		setError({
 			title: 'Transaction failed',
-			message: error.message,
+			message: getErrorMessage(error),
 			details: error,
 		});
 
@@ -244,12 +272,10 @@ export function useCryptoPaymentModalContext({
 
 			onSuccess(hash as Hash);
 		} catch (error) {
-			const errorObj =
-				error instanceof Error ? error : new Error(String(error));
+			const errorObj = toErrorWithDetails(error);
 			setError({
 				title: 'Purchase failed',
-				message:
-					errorObj.message || 'Failed to complete purchase. Please try again.',
+				message: getErrorMessage(errorObj),
 				details: errorObj,
 			});
 			console.error('Buy transaction failed:', error);
@@ -263,7 +289,7 @@ export function useCryptoPaymentModalContext({
 	};
 
 	const formattedPrice = formatPrice(
-		BigInt(priceAmount || 0),
+		buyStepPriceAmount,
 		currency?.decimals || 0,
 	);
 	const isFree = formattedPrice === '0';

--- a/sdk/src/utils/__tests__/getWebRPCErrorMessage.test.ts
+++ b/sdk/src/utils/__tests__/getWebRPCErrorMessage.test.ts
@@ -1,0 +1,28 @@
+import type { WebrpcError } from '@0xsequence/api-client';
+import { describe, expect, test } from 'vitest';
+import { getWebRPCErrorMessage } from '../getWebRPCErrorMessage';
+
+	describe('getWebRPCErrorMessage', () => {
+	test('maps OutOfFund endpoint errors to an insufficient balance message', () => {
+		const message = getWebRPCErrorMessage({
+			code: 0,
+			status: 400,
+			name: 'WebrpcEndpoint',
+			message: 'endpoint error',
+			cause: 'evm error: OutOfFund',
+		} as WebrpcError);
+
+		expect(message).toBe('Insufficient balance to complete this transaction.');
+	});
+
+	test('continues to map known WebRPC error codes', () => {
+		const message = getWebRPCErrorMessage({
+			code: 3000,
+			status: 404,
+			name: 'WebrpcNotFound',
+			message: 'not found',
+		} as WebrpcError);
+
+		expect(message).toBe('Item not found or no longer available.');
+	});
+});

--- a/sdk/src/utils/getWebRPCErrorMessage.ts
+++ b/sdk/src/utils/getWebRPCErrorMessage.ts
@@ -1,6 +1,20 @@
 import type { WebrpcError } from '@0xsequence/api-client';
 
 export const getWebRPCErrorMessage = (error: WebrpcError): string => {
+	const rawDetails = [error.message, String(error.cause ?? '')]
+		.join(' ')
+		.toLowerCase();
+
+	if (
+		rawDetails.includes('outoffund') ||
+		rawDetails.includes('out of fund') ||
+		rawDetails.includes('insufficient funds') ||
+		rawDetails.includes('insufficient balance') ||
+		rawDetails.includes('not enough balance')
+	) {
+		return 'Insufficient balance to complete this transaction.';
+	}
+
 	switch (error.code) {
 		// Protocol Errors (negative numbers)
 		case -1: // WebrpcRequestFailed

--- a/sdk/src/utils/getWebRPCErrorMessage.ts
+++ b/sdk/src/utils/getWebRPCErrorMessage.ts
@@ -1,7 +1,14 @@
 import type { WebrpcError } from '@0xsequence/api-client';
 
 export const getWebRPCErrorMessage = (error: WebrpcError): string => {
-	const rawDetails = [error.message, String(error.cause ?? '')]
+	const causeMessage =
+		typeof error.cause === 'string'
+			? error.cause
+			: error.cause instanceof Error
+				? error.cause.message
+				: '';
+
+	const rawDetails = [error.message, causeMessage]
 		.join(' ')
 		.toLowerCase();
 


### PR DESCRIPTION
If the users balance is not containing enoghf to also cover the fees, they get a webrpc error instead of a balance error see https://github.com/0xsequence/issue-tracker/issues/7033

Fixed by using the total sum